### PR TITLE
Add tag-gated PyPI release flow to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 on:
   push:
     branches: [main]
+    tags: ["v*"]
   pull_request:
 
 jobs:
@@ -173,3 +174,41 @@ jobs:
           files: ./coverage.xml
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  publish-pypi:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    needs: [full]
+    permissions:
+      contents: read
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/project/foldermix/
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Verify tag matches package version
+        run: |
+          python - <<'PY'
+          import os
+          import pathlib
+          import tomllib
+
+          version = tomllib.loads(pathlib.Path("pyproject.toml").read_text(encoding="utf-8"))["project"]["version"]
+          tag = os.environ["GITHUB_REF_NAME"]
+          expected = f"v{version}"
+          if tag != expected:
+              raise SystemExit(
+                  f"Tag {tag} does not match project version {version} (expected {expected})"
+              )
+          print(f"Tag/version check passed: {tag}")
+          PY
+      - name: Build package
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary
Add an Option-1 release flow in the existing CI workflow: publish to PyPI on version tag pushes.

## What changed
- Extended `.github/workflows/ci.yml` push trigger to include `v*` tags.
- Added `publish-pypi` job gated by `needs: full`.
- Configured OIDC-based publish via `pypa/gh-action-pypi-publish@release/v1`.
- Added a guard step to verify `GITHUB_REF_NAME` matches `v<project.version>` from `pyproject.toml`.

## Behavior
- Normal PR and branch CI behavior is unchanged.
- Publishing only runs for tag pushes like `v0.1.0`.
- Publish is blocked unless the full CI job succeeds.

## Notes
- Requires a GitHub environment named `pypi` configured for PyPI Trusted Publishing.
