### PR TITLE
Fix Homebrew tap update when formula is first added

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,13 +287,13 @@ jobs:
           cp /tmp/foldermix.rb homebrew-tap/Formula/foldermix.rb
 
           cd homebrew-tap
-          if git diff --quiet -- Formula/foldermix.rb; then
+          git add Formula/foldermix.rb
+          if git diff --cached --quiet -- Formula/foldermix.rb; then
             echo "Formula unchanged; nothing to commit."
             exit 0
           fi
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add Formula/foldermix.rb
           git commit -m "foldermix ${{ needs.publish-pypi.outputs.version }}"
           git push


### PR DESCRIPTION
## Summary
- fix Homebrew tap update commit detection in CI

## Root cause
`git diff -- Formula/foldermix.rb` ignores untracked files. On first publish, `foldermix.rb` is new/untracked, so CI incorrectly considered it unchanged and skipped commit/push.

## Fix
- stage formula first: `git add Formula/foldermix.rb`
- test staged diff instead: `git diff --cached --quiet -- Formula/foldermix.rb`

This correctly handles both new and modified formula files.
