### PR TITLE
Fix Homebrew install by using python3.12 executable

### DIFF
--- a/scripts/render_homebrew_formula.py
+++ b/scripts/render_homebrew_formula.py
@@ -13,6 +13,7 @@ DESCRIPTION = "Pack a folder into a single LLM-friendly context file"
 HOMEPAGE = "https://github.com/shaypal5/foldermix"
 LICENSE = "MIT"
 HOMEBREW_PYTHON_FORMULA = "python@3.12"
+HOMEBREW_PYTHON_EXECUTABLE = "python3.12"
 
 
 def _retry_backoff_seconds(attempt: int) -> int:
@@ -89,7 +90,7 @@ def _render_formula(
         [
             "",
             "  def install",
-            f'    venv = virtualenv_create(libexec, "{HOMEBREW_PYTHON_FORMULA}")',
+            f'    venv = virtualenv_create(libexec, "{HOMEBREW_PYTHON_EXECUTABLE}")',
             "    # Do not vendor compiled sdists (like pydantic-core), which can",
             "    # force Rust/LLVM downloads. Let pip resolve platform wheels.",
             "    venv.pip_install_and_link buildpath",

--- a/tests/test_render_homebrew_formula.py
+++ b/tests/test_render_homebrew_formula.py
@@ -26,7 +26,7 @@ def test_render_formula_avoids_rust_and_vendored_resources() -> None:
     assert 'depends_on "python@3.12"' in formula
     assert 'depends_on "rust" => :build' not in formula
     assert 'resource "' not in formula
-    assert 'venv = virtualenv_create(libexec, "python@3.12")' in formula
+    assert 'venv = virtualenv_create(libexec, "python3.12")' in formula
     assert "venv.pip_install_and_link buildpath" in formula
     assert 'assert_match "foldermix #{version}"' in formula
 


### PR DESCRIPTION
## Summary
- fix Homebrew formula generation to use `python3.12` (the executable) for `virtualenv_create`
- keep the dependency formula as `python@3.12`
- update renderer test assertion accordingly

## Why
Homebrew install was failing at venv creation with:
`python@3.12 -m venv ...`
which prevented the `foldermix` binary from being installed/linked.

## Validation
- ~/.pyenv/versions/foldermix/bin/python -m pytest tests/test_render_homebrew_formula.py -o addopts="-vv -ra --strict-markers --strict-config"
- ~/.pyenv/versions/foldermix/bin/ruff check scripts/render_homebrew_formula.py tests/test_render_homebrew_formula.py
