### PR TITLE
Fix Homebrew dependency install and release 0.1.7

### DIFF
--- a/foldermix/config.py
+++ b/foldermix/config.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
-
-from pydantic import BaseModel, Field
 
 DEFAULT_INCLUDE_EXT: list[str] = [
     ".txt",
@@ -112,15 +111,16 @@ SENSITIVE_PATTERNS: set[str] = {
 }
 
 
-class PackConfig(BaseModel):
+@dataclass(slots=True)
+class PackConfig:
     root: Path
     out: Path | None = None
     format: Literal["md", "xml", "jsonl"] = "md"
     include_ext: list[str] | None = None
-    exclude_ext: list[str] = Field(default_factory=lambda: list(DEFAULT_EXCLUDE_EXT))
-    exclude_dirs: list[str] = Field(default_factory=lambda: list(DEFAULT_EXCLUDE_DIRS))
-    exclude_glob: list[str] = Field(default_factory=list)
-    include_glob: list[str] = Field(default_factory=list)
+    exclude_ext: list[str] = field(default_factory=lambda: list(DEFAULT_EXCLUDE_EXT))
+    exclude_dirs: list[str] = field(default_factory=lambda: list(DEFAULT_EXCLUDE_DIRS))
+    exclude_glob: list[str] = field(default_factory=list)
+    include_glob: list[str] = field(default_factory=list)
     max_bytes: int = 10_000_000
     max_total_bytes: int | None = None
     max_files: int | None = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "foldermix"
-version = "0.1.6"
+version = "0.1.7"
 description = "Pack a folder into a single LLM-friendly context file"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -12,7 +12,6 @@ license = { file = "LICENSE" }
 keywords = ["llm", "context", "packing", "cli"]
 dependencies = [
     "typer>=0.9",
-    "pydantic>=2.0",
     "pathspec>=0.12",
     "rich>=13.0",
 ]

--- a/scripts/render_homebrew_formula.py
+++ b/scripts/render_homebrew_formula.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
+import subprocess
+import sys
+import tempfile
 import time
 import urllib.error
 import urllib.parse
@@ -13,7 +17,21 @@ DESCRIPTION = "Pack a folder into a single LLM-friendly context file"
 HOMEPAGE = "https://github.com/shaypal5/foldermix"
 LICENSE = "MIT"
 HOMEBREW_PYTHON_FORMULA = "python@3.12"
-HOMEBREW_PYTHON_EXECUTABLE = "python3.12"
+
+SKIP_FREEZE_PACKAGES = {
+    "foldermix",
+    "pip",
+    "setuptools",
+    "wheel",
+}
+
+
+def _normalize_name(name: str) -> str:
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def _run(cmd: list[str]) -> str:
+    return subprocess.check_output(cmd, text=True).strip()
 
 
 def _retry_backoff_seconds(attempt: int) -> int:
@@ -67,10 +85,47 @@ def _fetch_pypi_release_file(package: str, version: str, retries: int = 8) -> tu
     )
 
 
+def _resolve_runtime_deps(project_root: Path) -> list[tuple[str, str]]:
+    project_root = project_root.resolve()
+    with tempfile.TemporaryDirectory(prefix="foldermix-brew-") as tmp:
+        venv_dir = Path(tmp) / "venv"
+        python = Path(sys.executable)
+        _run([str(python), "-m", "venv", str(venv_dir)])
+
+        if sys.platform == "win32":
+            pip = venv_dir / "Scripts" / "pip.exe"
+        else:
+            pip = venv_dir / "bin" / "pip"
+
+        _run([str(pip), "install", "--disable-pip-version-check", "--upgrade", "pip"])
+        # Resolve dependency versions from the current source tree.
+        _run([str(pip), "install", "--disable-pip-version-check", str(project_root)])
+        freeze = _run([str(pip), "freeze", "--all"])
+
+    resolved: dict[str, tuple[str, str]] = {}
+    for line in freeze.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or line.startswith("-e "):
+            continue
+        if "@" in line:
+            # Skip direct URL/editable lines for robustness.
+            continue
+        if "==" not in line:
+            continue
+        name, dep_version = line.split("==", 1)
+        norm = _normalize_name(name)
+        if norm in SKIP_FREEZE_PACKAGES:
+            continue
+        resolved[norm] = (name, dep_version)
+
+    return [resolved[key] for key in sorted(resolved)]
+
+
 def _render_formula(
     package_version: str,
     package_url: str,
     package_sha256: str,
+    resources: list[tuple[str, str, str]],
 ) -> str:
     lines = [
         "class Foldermix < Formula",
@@ -86,14 +141,26 @@ def _render_formula(
         f'  depends_on "{HOMEBREW_PYTHON_FORMULA}"',
     ]
 
+    if resources:
+        lines.append("")
+
+    for index, (resource_name, resource_url, resource_sha) in enumerate(resources):
+        lines.extend(
+            [
+                f'  resource "{resource_name}" do',
+                f'    url "{resource_url}"',
+                f'    sha256 "{resource_sha}"',
+                "  end",
+            ]
+        )
+        if index != len(resources) - 1:
+            lines.append("")
+
     lines.extend(
         [
             "",
             "  def install",
-            f'    venv = virtualenv_create(libexec, "{HOMEBREW_PYTHON_EXECUTABLE}")',
-            "    # Do not vendor compiled sdists (like pydantic-core), which can",
-            "    # force Rust/LLVM downloads. Let pip resolve platform wheels.",
-            "    venv.pip_install_and_link buildpath",
+            "    virtualenv_install_with_resources",
             "  end",
             "",
             "  test do",
@@ -121,11 +188,25 @@ def main() -> int:
     args = parser.parse_args()
 
     package_url, package_sha = _fetch_pypi_release_file("foldermix", args.version)
+    project_root = Path(__file__).resolve().parents[1]
+    runtime_deps = _resolve_runtime_deps(project_root)
+
+    resources: list[tuple[str, str, str]] = []
+    for package_name, package_version in runtime_deps:
+        normalized = _normalize_name(package_name)
+        if normalized == "pydantic-core":
+            raise RuntimeError(
+                "Dependency resolution includes pydantic-core, which reintroduces Rust-heavy "
+                "Homebrew installs. Remove compiled runtime dependencies first."
+            )
+        resource_url, resource_sha = _fetch_pypi_release_file(package_name, package_version)
+        resources.append((normalized, resource_url, resource_sha))
 
     output = _render_formula(
         package_version=args.version,
         package_url=package_url,
         package_sha256=package_sha,
+        resources=resources,
     )
 
     output_path = Path(args.output)

--- a/tests/integration/fixtures/expected/simple_project.jsonl
+++ b/tests/integration/fixtures/expected/simple_project.jsonl
@@ -1,4 +1,4 @@
-{"type": "header", "root": "__ROOT__", "generated_at": "2024-01-02T00:00:00+00:00", "version": "0.1.6", "file_count": 3, "total_bytes": 32, "args": {}}
+{"type": "header", "root": "__ROOT__", "generated_at": "2024-01-02T00:00:00+00:00", "version": "0.1.7", "file_count": 3, "total_bytes": 32, "args": {}}
 {"type": "file", "path": "alpha.md", "ext": ".md", "size_bytes": 8, "mtime": "2024-01-01T00:00:00+00:00", "sha256": null, "converter": "text", "original_mime": "text/md", "warnings": [], "truncated": false, "content": "# Alpha\n"}
 {"type": "file", "path": "code.py", "ext": ".py", "size_bytes": 12, "mtime": "2024-01-01T00:00:00+00:00", "sha256": null, "converter": "text", "original_mime": "text/py", "warnings": [], "truncated": false, "content": "print(\"hi\")\n"}
 {"type": "file", "path": "nested/note.txt", "ext": ".txt", "size_bytes": 12, "mtime": "2024-01-01T00:00:00+00:00", "sha256": null, "converter": "text", "original_mime": "text/txt", "warnings": [], "truncated": false, "content": "line1\nline2\n"}

--- a/tests/integration/fixtures/expected/simple_project.md
+++ b/tests/integration/fixtures/expected/simple_project.md
@@ -2,7 +2,7 @@
 
 - **Root**: `__ROOT__`
 - **Generated**: 2024-01-02T00:00:00+00:00
-- **Version**: 0.1.6
+- **Version**: 0.1.7
 - **Files**: 3
 - **Total bytes**: 32
 

--- a/tests/integration/fixtures/expected/simple_project.xml
+++ b/tests/integration/fixtures/expected/simple_project.xml
@@ -3,7 +3,7 @@
   <header>
     <root>__ROOT__</root>
     <generated_at>2024-01-02T00:00:00+00:00</generated_at>
-    <version>0.1.6</version>
+    <version>0.1.7</version>
     <file_count>3</file_count>
     <total_bytes>32</total_bytes>
   </header>

--- a/tests/test_render_homebrew_formula.py
+++ b/tests/test_render_homebrew_formula.py
@@ -15,19 +15,37 @@ def _load_renderer_module():
     return module
 
 
-def test_render_formula_avoids_rust_and_vendored_resources() -> None:
+def test_normalize_name() -> None:
+    module = _load_renderer_module()
+    assert module._normalize_name("Pydantic_Core") == "pydantic-core"
+    assert module._normalize_name("typing.extensions") == "typing-extensions"
+
+
+def test_render_formula_includes_resources_without_rust() -> None:
     module = _load_renderer_module()
     formula = module._render_formula(
         package_version="0.1.1",
         package_url="https://files.pythonhosted.org/foldermix-0.1.1.tar.gz",
         package_sha256="abc123",
+        resources=[
+            (
+                "typer",
+                "https://files.pythonhosted.org/typer-0.20.0.tar.gz",
+                "r1",
+            ),
+            (
+                "rich",
+                "https://files.pythonhosted.org/rich-14.0.0.tar.gz",
+                "r2",
+            ),
+        ],
     )
 
     assert 'depends_on "python@3.12"' in formula
     assert 'depends_on "rust" => :build' not in formula
-    assert 'resource "' not in formula
-    assert 'venv = virtualenv_create(libexec, "python3.12")' in formula
-    assert "venv.pip_install_and_link buildpath" in formula
+    assert 'resource "typer" do' in formula
+    assert 'resource "rich" do' in formula
+    assert "virtualenv_install_with_resources" in formula
     assert 'assert_match "foldermix #{version}"' in formula
 
 
@@ -80,3 +98,35 @@ def test_fetch_http_500_failure_mentions_url(monkeypatch) -> None:
         assert "HTTP 500" in text
     else:
         raise AssertionError("Expected RuntimeError")
+
+
+def test_resolve_runtime_deps_installs_local_project(monkeypatch, tmp_path: Path) -> None:
+    module = _load_renderer_module()
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+
+    commands: list[list[str]] = []
+
+    def fake_run(cmd: list[str]) -> str:
+        commands.append(cmd)
+        if cmd[-2:] == ["freeze", "--all"]:
+            return "\n".join(
+                [
+                    "foldermix==0.1.7",
+                    "rich==14.3.3",
+                    "pathspec==1.0.4",
+                    "pip==25.0.0",
+                ]
+            )
+        return ""
+
+    monkeypatch.setattr(module, "_run", fake_run)
+    monkeypatch.setattr(module.sys, "executable", "/usr/bin/python3")
+
+    deps = module._resolve_runtime_deps(project_root)
+
+    assert ("pathspec", "1.0.4") in deps
+    assert ("rich", "14.3.3") in deps
+    assert ("foldermix", "0.1.7") not in deps
+    assert any(len(cmd) >= 3 and cmd[1:3] == ["-m", "venv"] for cmd in commands)
+    assert any(str(project_root) in cmd for cmd in commands)


### PR DESCRIPTION
## Summary
- fix Homebrew runtime failure by restoring vendored dependency resources in generated formula (`virtualenv_install_with_resources`)
- remove `pydantic` runtime dependency so Homebrew formula stays pure-Python and avoids Rust/LLVM toolchain pulls
- add a generator guard that fails if `pydantic-core` reappears in resolved runtime deps
- bump release version to `0.1.7` and update expected snapshot fixture headers

## Why this fixes your failure
`0.1.6` formula installed only `foldermix` itself, so runtime deps (e.g. `typer`) were missing and `foldermix version` crashed with `ModuleNotFoundError`.

This PR restores deterministic dependency installation inside Homebrew's offline build model.

## Validation
- ~/.pyenv/versions/foldermix/bin/ruff check foldermix/config.py scripts/render_homebrew_formula.py tests/test_render_homebrew_formula.py pyproject.toml
- ~/.pyenv/versions/foldermix/bin/python -m pytest tests/test_render_homebrew_formula.py -o addopts="-vv -ra --strict-markers --strict-config"
- ~/.pyenv/versions/foldermix/bin/python -m pytest -m "not integration and not slow" -o addopts="-vv -ra --strict-markers --strict-config"
