### PR TITLE
Implement #29: add release consumer smoke validation (PyPI + Homebrew)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,36 +251,46 @@ jobs:
       needs.publish-pypi.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
     needs: [publish-pypi]
+    outputs:
+      tap_update_enabled: ${{ steps.tap_guard.outputs.tap_update_enabled }}
     permissions:
       contents: read
     env:
       TAP_REPOSITORY: shaypal5/homebrew-tap
       HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
     steps:
+      - name: Detect whether tap updates are enabled
+        id: tap_guard
+        run: |
+          if [ -n "${HOMEBREW_TAP_GITHUB_TOKEN}" ]; then
+            echo "tap_update_enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "tap_update_enabled=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Skip tap update (token not configured)
-        if: env.HOMEBREW_TAP_GITHUB_TOKEN == ''
+        if: steps.tap_guard.outputs.tap_update_enabled != 'true'
         run: echo "No HOMEBREW_TAP_GITHUB_TOKEN configured; skipping tap update."
       - uses: actions/checkout@v4
-        if: env.HOMEBREW_TAP_GITHUB_TOKEN != ''
+        if: steps.tap_guard.outputs.tap_update_enabled == 'true'
       - uses: actions/setup-python@v6
-        if: env.HOMEBREW_TAP_GITHUB_TOKEN != ''
+        if: steps.tap_guard.outputs.tap_update_enabled == 'true'
         with:
           python-version: "3.12"
       - name: Render Homebrew formula from published version
-        if: env.HOMEBREW_TAP_GITHUB_TOKEN != ''
+        if: steps.tap_guard.outputs.tap_update_enabled == 'true'
         run: |
           python scripts/render_homebrew_formula.py \
             --version "${{ needs.publish-pypi.outputs.version }}" \
             --output /tmp/foldermix.rb
       - name: Checkout tap repository
-        if: env.HOMEBREW_TAP_GITHUB_TOKEN != ''
+        if: steps.tap_guard.outputs.tap_update_enabled == 'true'
         uses: actions/checkout@v4
         with:
           repository: ${{ env.TAP_REPOSITORY }}
           token: ${{ env.HOMEBREW_TAP_GITHUB_TOKEN }}
           path: homebrew-tap
       - name: Update tap formula and push
-        if: env.HOMEBREW_TAP_GITHUB_TOKEN != ''
+        if: steps.tap_guard.outputs.tap_update_enabled == 'true'
         run: |
           set -euo pipefail
           mkdir -p homebrew-tap/Formula
@@ -399,7 +409,8 @@ jobs:
     if: >-
       github.event_name == 'push' &&
       github.ref == 'refs/heads/main' &&
-      needs.publish-pypi.outputs.should_publish == 'true'
+      needs.publish-pypi.outputs.should_publish == 'true' &&
+      needs.update-homebrew-tap.outputs.tap_update_enabled == 'true'
     runs-on: macos-latest
     needs: [publish-pypi, update-homebrew-tap]
     permissions:

--- a/README.md
+++ b/README.md
@@ -324,9 +324,9 @@ A release is triggered by merging a PR to `main` that bumps the `version` field 
 
 4. **Open the PR** targeting `main` and wait for all CI jobs to pass.
 
-5. **Merge to `main`**. The `publish-pypi` job will detect the version bump, build the wheel, and publish to PyPI automatically. The `update-homebrew-tap` job will then update the Homebrew formula, and release-consumer smoke jobs will validate fresh installs from both PyPI and Homebrew.
+5. **Merge to `main`**. The `publish-pypi` job will detect the version bump, build the wheel, and publish to PyPI automatically. The `update-homebrew-tap` job will then update the Homebrew formula, and release-consumer smoke jobs will validate fresh installs from PyPI and, when tap credentials are configured, from Homebrew.
 
-> **Note:** If `HOMEBREW_TAP_GITHUB_TOKEN` is not configured the tap-update step is silently skipped. Configure it as a repository secret with write access to `shaypal5/homebrew-tap` before the first release.
+> **Note:** If `HOMEBREW_TAP_GITHUB_TOKEN` is not configured, both tap update and Homebrew release-consumer smoke are skipped. Configure it as a repository secret with write access to `shaypal5/homebrew-tap` before the first release.
 
 ## License
 


### PR DESCRIPTION
## Summary
Implements roadmap issue #29 by adding release-consumer smoke validation for published install paths.

Closes #29.
Part of #40 (M1 Local Foundation roadmap tracker).

## What Changed
### CI workflow updates (`.github/workflows/ci.yml`)
Added two release-only jobs that run after publish logic on `main` pushes with a version bump (`needs.publish-pypi.outputs.should_publish == 'true'`):

1. `release-consumer-smoke-pypi` (Ubuntu)
- Installs the just-published version from PyPI (`foldermix==<released_version>`).
- Includes retry logic for short PyPI propagation lag.
- Runs black-box CLI checks:
  - `foldermix version`
  - `foldermix list`
  - `foldermix pack`
- Verifies Python import/runtime path (`import foldermix; print(__version__)`).

2. `release-consumer-smoke-homebrew` (macOS)
- Installs from `shaypal5/tap` after `update-homebrew-tap`.
- Runs black-box CLI checks:
  - `foldermix version`
  - `foldermix list`
  - `foldermix pack`

### Diagnostics / failure quality
Both new jobs:
- use explicit command wrappers with clear failure messages (`::error::...`).
- collect step logs into `release-consumer-logs/*.log`.
- always upload logs via `actions/upload-artifact@v4` (retention 14 days).

This provides actionable troubleshooting evidence for install/runtime/import failures in consumer paths.

### Docs updates (`README.md`)
- Updated CI workflow pipeline description to include new release-consumer jobs.
- Added job-level documentation bullets for both new jobs.
- Updated release process text to reflect post-publish consumer validation.

## Scope alignment with issue #29
- Triggered on publish path (`main` push + version bump).
- Verifies Linux consumer install path from PyPI.
- Verifies macOS consumer install path from Homebrew tap.
- Runs required black-box CLI checks (`version`, `list`, `pack`).
- Preserves smoke-only intent (not exhaustive functional testing).

## Local validation evidence
Executed locally:
- `ruff check .`
- `ruff format --check .`
- `pytest -m "not integration and not slow" -o addopts=`

All passed.