### PR TITLE
Add built-in policy packs (M2-02)

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,33 @@ content_regex = "SECRET_[0-9]+"
 Each rule must include at least one matcher key:
 `path_glob`, `ext_in`, `skip_reason_in`, `content_regex`, `max_size_bytes`, `max_total_bytes`, or `max_file_count`.
 
+### Built-in Policy Packs
+
+Use `--policy-pack` to apply a built-in rule bundle:
+
+```bash
+foldermix pack . --policy-pack strict-privacy --report report.json
+```
+
+Or persist it in `foldermix.toml`:
+
+```toml
+[pack]
+policy_pack = "strict-privacy" # strict-privacy | legal-hold | customer-support
+```
+
+Pack intents and tradeoffs:
+
+- `strict-privacy`:
+  prioritize deny-level findings for direct PII/secret markers; higher false-positive tolerance.
+- `legal-hold`:
+  advisory warnings for legal-retention signals (privileged/destruction markers, hidden-scan coverage).
+- `customer-support`:
+  advisory findings focused on contact PII and log-like support artifacts.
+
+`policy_pack` rules are combined with explicit `policy_rules` (pack rules first, then custom rules).
+Unknown pack names fail with a clear validation error.
+
 ## Troubleshooting
 
 - `--null` requires `--stdin`

--- a/foldermix/cli.py
+++ b/foldermix/cli.py
@@ -62,6 +62,7 @@ _PACK_PARAM_BY_KEY = {
     "include_toc": "include_toc",
     "pdf_ocr": "pdf_ocr",
     "pdf_ocr_strict": "pdf_ocr_strict",
+    "policy_pack": "policy_pack",
     "policy_rules": "policy_rules",
 }
 
@@ -229,6 +230,11 @@ def pack_cmd(
         "--pdf-ocr-strict/--no-pdf-ocr-strict",
         help="Fail conversion when OCR is required but unavailable or unsuccessful [default: disabled]",
     ),
+    policy_pack: str | None = typer.Option(
+        None,
+        "--policy-pack",
+        help="Apply a built-in policy pack (strict-privacy, legal-hold, customer-support)",
+    ),
     stdin: bool = typer.Option(
         False,
         "--stdin",
@@ -304,6 +310,7 @@ def pack_cmd(
         "include_toc": include_toc,
         "pdf_ocr": pdf_ocr,
         "pdf_ocr_strict": pdf_ocr_strict,
+        "policy_pack": policy_pack,
         "policy_rules": [],
     }
 

--- a/foldermix/config.py
+++ b/foldermix/config.py
@@ -142,4 +142,5 @@ class PackConfig:
     include_toc: bool = True
     pdf_ocr: bool = False
     pdf_ocr_strict: bool = False
+    policy_pack: str | None = None
     policy_rules: list[dict[str, object]] = field(default_factory=list)

--- a/foldermix/config_loader.py
+++ b/foldermix/config_loader.py
@@ -39,6 +39,7 @@ _COMMAND_KEYS: dict[str, set[str]] = {
         "include_toc",
         "pdf_ocr",
         "pdf_ocr_strict",
+        "policy_pack",
         "policy_rules",
     },
     "list": {"include_ext", "exclude_ext", "hidden", "respect_gitignore"},
@@ -134,6 +135,12 @@ def _coerce_list_str(value: Any, key: str, errors: list[str], *, where: str) -> 
 
 
 def _coerce_value(key: str, value: Any, errors: list[str], *, where: str) -> Any:
+    if key == "policy_pack":
+        if not isinstance(value, str) or not value.strip():
+            errors.append(f"{where}.policy_pack: expected a non-empty string")
+            return value
+        return value
+
     if key == "policy_rules":
         return _coerce_policy_rules(value, errors, where=where)
 

--- a/foldermix/packer.py
+++ b/foldermix/packer.py
@@ -18,6 +18,7 @@ from .converters.pptx_fallback import PptxFallbackConverter
 from .converters.text import TextConverter
 from .converters.xlsx_fallback import XlsxFallbackConverter
 from .policy import PolicyEvaluator, normalize_policy_rules
+from .policy_packs import combine_policy_rules
 from .report import (
     ReportData,
     build_included_file_entry,
@@ -169,11 +170,20 @@ def _convert_record(
 def pack(config: PackConfig) -> None:
     """Main entry point for packing."""
     policy_evaluator: PolicyEvaluator | None = None
-    if config.policy_rules:
+    try:
+        raw_policy_rules = combine_policy_rules(
+            policy_pack=config.policy_pack,
+            policy_rules=config.policy_rules,
+        )
+    except ValueError as exc:
+        console.print(f"[red]Invalid policy configuration:[/red] {exc}")
+        raise typer.Exit(code=1) from exc
+
+    if raw_policy_rules:
         try:
-            policy_rules = normalize_policy_rules(config.policy_rules)
+            policy_rules = normalize_policy_rules(raw_policy_rules)
         except ValueError as exc:
-            console.print(f"[red]Invalid policy_rules:[/red] {exc}")
+            console.print(f"[red]Invalid policy configuration:[/red] {exc}")
             raise typer.Exit(code=1) from exc
         policy_evaluator = PolicyEvaluator(policy_rules)
 

--- a/foldermix/policy_packs.py
+++ b/foldermix/policy_packs.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import TypedDict
+
+
+class PolicyPackDefinition(TypedDict):
+    version: int
+    description: str
+    rules: list[dict[str, object]]
+
+
+POLICY_PACKS_VERSION = 1
+
+
+_POLICY_PACKS: dict[str, PolicyPackDefinition] = {
+    "strict-privacy": {
+        "version": POLICY_PACKS_VERSION,
+        "description": (
+            "Prioritize strict privacy controls by flagging direct PII/secret indicators "
+            "with deny-level severities."
+        ),
+        "rules": [
+            {
+                "rule_id": "strict-privacy-hidden-or-sensitive-scan",
+                "description": "Skipped hidden or sensitive files should be reviewed",
+                "stage": "scan",
+                "severity": "medium",
+                "action": "warn",
+                "skip_reason_in": ["hidden", "sensitive"],
+            },
+            {
+                "rule_id": "strict-privacy-email",
+                "description": "Detected email-like content",
+                "stage": "convert",
+                "severity": "high",
+                "action": "deny",
+                "content_regex": r"(?i)[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}",
+            },
+            {
+                "rule_id": "strict-privacy-phone",
+                "description": "Detected phone-like content",
+                "stage": "convert",
+                "severity": "high",
+                "action": "deny",
+                "content_regex": r"(?:\+?\d[\d .-]{7,}\d)",
+            },
+            {
+                "rule_id": "strict-privacy-secret-token",
+                "description": "Detected secret-like token marker",
+                "stage": "convert",
+                "severity": "critical",
+                "action": "deny",
+                "content_regex": r"(?i)(api[_-]?key|secret|token)\s*[:=]",
+            },
+        ],
+    },
+    "legal-hold": {
+        "version": POLICY_PACKS_VERSION,
+        "description": (
+            "Surface likely legal-retention signals so potentially relevant material "
+            "is not silently overlooked."
+        ),
+        "rules": [
+            {
+                "rule_id": "legal-hold-privileged-marker",
+                "description": "Detected privileged/legal-work marker",
+                "stage": "convert",
+                "severity": "high",
+                "action": "warn",
+                "content_regex": r"(?i)(attorney-client|privileged|work product)",
+            },
+            {
+                "rule_id": "legal-hold-destruction-marker",
+                "description": "Detected deletion or destruction marker",
+                "stage": "convert",
+                "severity": "medium",
+                "action": "warn",
+                "content_regex": r"(?i)\b(delete|destroy|purge)\b",
+            },
+            {
+                "rule_id": "legal-hold-hidden-scan",
+                "description": "Hidden files should be reviewed for legal hold completeness",
+                "stage": "scan",
+                "severity": "low",
+                "action": "warn",
+                "skip_reason_in": ["hidden"],
+            },
+        ],
+    },
+    "customer-support": {
+        "version": POLICY_PACKS_VERSION,
+        "description": (
+            "Highlight support-facing PII and operational log content while keeping "
+            "policy outcomes advisory."
+        ),
+        "rules": [
+            {
+                "rule_id": "customer-support-contact-email",
+                "description": "Detected customer email marker",
+                "stage": "convert",
+                "severity": "medium",
+                "action": "warn",
+                "content_regex": r"(?i)[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}",
+            },
+            {
+                "rule_id": "customer-support-contact-phone",
+                "description": "Detected customer phone marker",
+                "stage": "convert",
+                "severity": "medium",
+                "action": "warn",
+                "content_regex": r"(?:\+?\d[\d .-]{7,}\d)",
+            },
+            {
+                "rule_id": "customer-support-log-file",
+                "description": "Log-like files should be reviewed for support context quality",
+                "stage": "scan",
+                "severity": "low",
+                "action": "warn",
+                "path_glob": "*trace.txt",
+            },
+        ],
+    },
+}
+
+
+def available_policy_packs() -> tuple[str, ...]:
+    return tuple(sorted(_POLICY_PACKS))
+
+
+def get_policy_pack_definition(name: str) -> PolicyPackDefinition:
+    definition = _POLICY_PACKS.get(name)
+    if definition is None:
+        choices = ", ".join(available_policy_packs())
+        raise ValueError(f"Unknown policy pack {name!r}. Valid choices are: {choices}")
+    return deepcopy(definition)
+
+
+def get_policy_pack_rules(name: str) -> list[dict[str, object]]:
+    return get_policy_pack_definition(name)["rules"]
+
+
+def combine_policy_rules(
+    *, policy_pack: str | None, policy_rules: list[dict[str, object]]
+) -> list[dict[str, object]]:
+    combined: list[dict[str, object]] = []
+    if policy_pack is not None:
+        combined.extend(get_policy_pack_rules(policy_pack))
+    combined.extend(deepcopy(policy_rules))
+    return combined

--- a/tests/integration/fixtures/expected/policy_pack_deltas.json
+++ b/tests/integration/fixtures/expected/policy_pack_deltas.json
@@ -1,0 +1,72 @@
+{
+  "customer-support": {
+    "pack_version": 1,
+    "policy_finding_counts": {
+      "by_action": {
+        "warn": 3
+      },
+      "by_reason_code": {
+        "POLICY_CONTENT_REGEX_MATCH": 2,
+        "POLICY_RULE_MATCH": 1
+      },
+      "by_severity": {
+        "low": 1,
+        "medium": 2
+      },
+      "total": 3
+    },
+    "rule_ids": [
+      "customer-support-contact-email",
+      "customer-support-contact-phone",
+      "customer-support-log-file"
+    ]
+  },
+  "legal-hold": {
+    "pack_version": 1,
+    "policy_finding_counts": {
+      "by_action": {
+        "warn": 3
+      },
+      "by_reason_code": {
+        "POLICY_CONTENT_REGEX_MATCH": 2,
+        "POLICY_SKIP_REASON_MATCH": 1
+      },
+      "by_severity": {
+        "high": 1,
+        "low": 1,
+        "medium": 1
+      },
+      "total": 3
+    },
+    "rule_ids": [
+      "legal-hold-destruction-marker",
+      "legal-hold-hidden-scan",
+      "legal-hold-privileged-marker"
+    ]
+  },
+  "strict-privacy": {
+    "pack_version": 1,
+    "policy_finding_counts": {
+      "by_action": {
+        "deny": 3,
+        "warn": 1
+      },
+      "by_reason_code": {
+        "POLICY_CONTENT_REGEX_MATCH": 3,
+        "POLICY_SKIP_REASON_MATCH": 1
+      },
+      "by_severity": {
+        "critical": 1,
+        "high": 2,
+        "medium": 1
+      },
+      "total": 4
+    },
+    "rule_ids": [
+      "strict-privacy-email",
+      "strict-privacy-hidden-or-sensitive-scan",
+      "strict-privacy-phone",
+      "strict-privacy-secret-token"
+    ]
+  }
+}

--- a/tests/integration/fixtures/policy_pack_corpus/.hidden-note.txt
+++ b/tests/integration/fixtures/policy_pack_corpus/.hidden-note.txt
@@ -1,0 +1,1 @@
+TOKEN=abc123

--- a/tests/integration/fixtures/policy_pack_corpus/legal_memo.txt
+++ b/tests/integration/fixtures/policy_pack_corpus/legal_memo.txt
@@ -1,0 +1,2 @@
+Attorney-client privileged communication.
+Please do not destroy or purge related records.

--- a/tests/integration/fixtures/policy_pack_corpus/secrets.txt
+++ b/tests/integration/fixtures/policy_pack_corpus/secrets.txt
@@ -1,0 +1,1 @@
+api_key: SECRET_12345

--- a/tests/integration/fixtures/policy_pack_corpus/support-trace.txt
+++ b/tests/integration/fixtures/policy_pack_corpus/support-trace.txt
@@ -1,0 +1,1 @@
+INFO startup complete

--- a/tests/integration/fixtures/policy_pack_corpus/ticket.txt
+++ b/tests/integration/fixtures/policy_pack_corpus/ticket.txt
@@ -1,0 +1,2 @@
+Customer email: alice@example.com
+Phone: +1 415-555-0101

--- a/tests/integration/test_policy_packs.py
+++ b/tests/integration/test_policy_packs.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from foldermix import packer
+from foldermix.config import PackConfig
+from foldermix.policy_packs import available_policy_packs, get_policy_pack_definition
+
+pytestmark = pytest.mark.integration
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+
+def _run_pack_with_policy_pack(
+    tmp_path: Path, *, policy_pack: str, fixture_root: Path
+) -> dict[str, object]:
+    corpus_dir = tmp_path / f"corpus-{policy_pack}"
+    shutil.copytree(fixture_root, corpus_dir)
+    out_path = tmp_path / f"bundle-{policy_pack}.jsonl"
+    report_path = tmp_path / f"report-{policy_pack}.json"
+    config = PackConfig(
+        root=corpus_dir,
+        out=out_path,
+        format="jsonl",
+        report=report_path,
+        workers=1,
+        include_sha256=False,
+        policy_pack=policy_pack,
+    )
+    packer.pack(config)
+    return json.loads(report_path.read_text(encoding="utf-8"))
+
+
+def test_builtin_policy_packs_report_deltas_match_snapshot(tmp_path: Path) -> None:
+    fixture_root = FIXTURE_DIR / "policy_pack_corpus"
+    expected_path = FIXTURE_DIR / "expected" / "policy_pack_deltas.json"
+
+    summary: dict[str, object] = {}
+    for pack_name in available_policy_packs():
+        report = _run_pack_with_policy_pack(
+            tmp_path, policy_pack=pack_name, fixture_root=fixture_root
+        )
+        summary[pack_name] = {
+            "pack_version": get_policy_pack_definition(pack_name)["version"],
+            "policy_finding_counts": report["policy_finding_counts"],
+            "rule_ids": sorted({finding["rule_id"] for finding in report["policy_findings"]}),
+        }
+
+    expected = json.loads(expected_path.read_text(encoding="utf-8"))
+    assert summary == expected

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -118,6 +118,7 @@ def test_pack_loads_values_from_config_file(monkeypatch, tmp_path: Path) -> None
                 'include_ext = [".py", ".md"]',
                 "include_sha256 = false",
                 "pdf_ocr = true",
+                'policy_pack = "legal-hold"',
                 "",
                 "[[pack.policy_rules]]",
                 'rule_id = "scan-large"',
@@ -138,6 +139,7 @@ def test_pack_loads_values_from_config_file(monkeypatch, tmp_path: Path) -> None
     assert config.include_ext == [".py", ".md"]
     assert config.include_sha256 is False
     assert config.pdf_ocr is True
+    assert config.policy_pack == "legal-hold"
     assert config.policy_rules == [
         {
             "rule_id": "scan-large",
@@ -163,6 +165,7 @@ def test_pack_cli_flags_override_config_values(monkeypatch, tmp_path: Path) -> N
                 "[pack]",
                 'format = "xml"',
                 "include_toc = false",
+                'policy_pack = "legal-hold"',
                 "",
             ]
         ),
@@ -179,6 +182,8 @@ def test_pack_cli_flags_override_config_values(monkeypatch, tmp_path: Path) -> N
             "--format",
             "jsonl",
             "--include-toc",
+            "--policy-pack",
+            "strict-privacy",
         ],
     )
 
@@ -186,6 +191,7 @@ def test_pack_cli_flags_override_config_values(monkeypatch, tmp_path: Path) -> N
     config = captured["config"]
     assert config.format == "jsonl"
     assert config.include_toc is True
+    assert config.policy_pack == "strict-privacy"
 
 
 def test_pack_reports_invalid_config(tmp_path: Path) -> None:

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -536,6 +536,23 @@ def test_load_command_config_accepts_policy_rules_tables(tmp_path: Path) -> None
     ]
 
 
+def test_load_command_config_accepts_policy_pack_string(tmp_path: Path) -> None:
+    config_path = tmp_path / "foldermix.toml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "[pack]",
+                'policy_pack = "strict-privacy"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    values, _ = load_command_config("pack", root=tmp_path, config_path=config_path)
+    assert values["policy_pack"] == "strict-privacy"
+
+
 def test_load_command_config_rejects_policy_rule_without_matchers(tmp_path: Path) -> None:
     config_path = tmp_path / "foldermix.toml"
     config_path.write_text(
@@ -575,6 +592,25 @@ def test_load_command_config_rejects_policy_rules_when_not_a_list(tmp_path: Path
         load_command_config("pack", root=tmp_path, config_path=config_path)
 
     assert "expected a list of policy rule tables" in str(exc.value)
+
+
+def test_load_command_config_rejects_non_string_policy_pack(tmp_path: Path) -> None:
+    config_path = tmp_path / "foldermix.toml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "[pack]",
+                "policy_pack = 1",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ConfigLoadError) as exc:
+        load_command_config("pack", root=tmp_path, config_path=config_path)
+
+    assert "policy_pack: expected a non-empty string" in str(exc.value)
 
 
 def test_load_command_config_rejects_policy_rule_entry_when_not_table(tmp_path: Path) -> None:

--- a/tests/test_packer.py
+++ b/tests/test_packer.py
@@ -328,6 +328,58 @@ def test_pack_policy_scan_evaluates_skipped_records(tmp_path: Path) -> None:
     assert finding["reason_code"] == "POLICY_SKIP_REASON_MATCH"
 
 
+def test_pack_rejects_unknown_policy_pack(tmp_path: Path) -> None:
+    (tmp_path / "a.txt").write_text("hello\n", encoding="utf-8")
+    config = PackConfig(
+        root=tmp_path,
+        out=tmp_path / "out.md",
+        workers=1,
+        policy_pack="does-not-exist",
+    )
+
+    with pytest.raises(typer.Exit) as exc_info:
+        packer.pack(config)
+
+    assert exc_info.value.exit_code == 1
+
+
+def test_pack_combines_builtin_policy_pack_with_custom_rules(tmp_path: Path) -> None:
+    (tmp_path / "ticket.txt").write_text(
+        "Customer email: alice@example.com\nPhone: +1 415-555-0101\n",
+        encoding="utf-8",
+    )
+    (tmp_path / ".env").write_text("TOKEN=abc123\n", encoding="utf-8")
+    out_path = tmp_path / "out.jsonl"
+    report_path = tmp_path / "report.json"
+    config = PackConfig(
+        root=tmp_path,
+        out=out_path,
+        format="jsonl",
+        report=report_path,
+        workers=1,
+        include_sha256=False,
+        policy_pack="customer-support",
+        policy_rules=[
+            {
+                "rule_id": "custom-hidden-scan",
+                "description": "Flag hidden skips",
+                "stage": "scan",
+                "skip_reason_in": ["hidden"],
+                "severity": "high",
+                "action": "deny",
+            }
+        ],
+    )
+
+    packer.pack(config)
+
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    rule_ids = {finding["rule_id"] for finding in report["policy_findings"]}
+    assert "customer-support-contact-email" in rule_ids
+    assert "customer-support-contact-phone" in rule_ids
+    assert "custom-hidden-scan" in rule_ids
+
+
 def test_pack_keeps_deterministic_order_after_parallel_conversion(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/tests/test_policy_packs.py
+++ b/tests/test_policy_packs.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import pytest
+
+from foldermix.policy_packs import (
+    POLICY_PACKS_VERSION,
+    available_policy_packs,
+    combine_policy_rules,
+    get_policy_pack_definition,
+    get_policy_pack_rules,
+)
+
+
+def test_available_policy_packs_are_stable() -> None:
+    assert available_policy_packs() == (
+        "customer-support",
+        "legal-hold",
+        "strict-privacy",
+    )
+
+
+def test_policy_pack_definition_is_versioned() -> None:
+    definition = get_policy_pack_definition("strict-privacy")
+    assert definition["version"] == POLICY_PACKS_VERSION
+    assert definition["rules"]
+
+
+def test_get_policy_pack_rules_returns_independent_copy() -> None:
+    first = get_policy_pack_rules("legal-hold")
+    second = get_policy_pack_rules("legal-hold")
+    first[0]["rule_id"] = "mutated"
+    assert second[0]["rule_id"] != "mutated"
+
+
+def test_combine_policy_rules_appends_custom_rules_after_pack() -> None:
+    combined = combine_policy_rules(
+        policy_pack="customer-support",
+        policy_rules=[
+            {
+                "rule_id": "custom-one",
+                "description": "custom",
+                "path_glob": "*.txt",
+            }
+        ],
+    )
+
+    assert combined[-1]["rule_id"] == "custom-one"
+    assert any(rule["rule_id"] == "customer-support-log-file" for rule in combined)
+
+
+def test_unknown_policy_pack_raises_clear_error() -> None:
+    with pytest.raises(ValueError, match="Unknown policy pack"):
+        get_policy_pack_rules("does-not-exist")

--- a/tests/test_snapshot_guard.py
+++ b/tests/test_snapshot_guard.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+import json
+import shutil
 from pathlib import Path
 
+from foldermix import packer
+from foldermix.config import PackConfig
+from foldermix.policy_packs import available_policy_packs, get_policy_pack_definition
 from tests.snapshot_helpers import render_simple_project_snapshot
 
 FIXTURE_DIR = Path(__file__).parent / "integration" / "fixtures"
@@ -26,3 +31,34 @@ def test_simple_project_expected_snapshots_are_in_sync(tmp_path: Path, monkeypat
         )
         expected = (expected_dir / expected_name).read_text(encoding="utf-8")
         assert actual == expected, f"{fmt} snapshot fixture drifted: {expected_name}"
+
+
+def test_policy_pack_expected_snapshots_are_in_sync(tmp_path: Path) -> None:
+    expected_path = FIXTURE_DIR / "expected" / "policy_pack_deltas.json"
+    corpus_root = FIXTURE_DIR / "policy_pack_corpus"
+
+    summary: dict[str, object] = {}
+    for pack_name in available_policy_packs():
+        corpus_dir = tmp_path / f"corpus-{pack_name}"
+        shutil.copytree(corpus_root, corpus_dir)
+        out_path = tmp_path / f"bundle-{pack_name}.jsonl"
+        report_path = tmp_path / f"report-{pack_name}.json"
+        config = PackConfig(
+            root=corpus_dir,
+            out=out_path,
+            format="jsonl",
+            report=report_path,
+            workers=1,
+            include_sha256=False,
+            policy_pack=pack_name,
+        )
+        packer.pack(config)
+        report = json.loads(report_path.read_text(encoding="utf-8"))
+        summary[pack_name] = {
+            "pack_version": get_policy_pack_definition(pack_name)["version"],
+            "policy_finding_counts": report["policy_finding_counts"],
+            "rule_ids": sorted({finding["rule_id"] for finding in report["policy_findings"]}),
+        }
+
+    expected = json.loads(expected_path.read_text(encoding="utf-8"))
+    assert summary == expected, "policy pack snapshot fixture drifted: policy_pack_deltas.json"


### PR DESCRIPTION
## Summary
Implements roadmap issue #32 by adding versioned built-in policy packs and wiring them into the pack pipeline via `--policy-pack` / `foldermix.toml`.

Closes #32.

## What Changed
- Added a new policy-pack catalog module:
  - `foldermix/policy_packs.py`
  - Built-in packs: `strict-privacy`, `legal-hold`, `customer-support`
  - Pack metadata includes a version marker (`POLICY_PACKS_VERSION`)
  - Added deterministic helpers to list, load, and combine pack rules with user-defined `policy_rules`
- Extended config surface:
  - `PackConfig` now includes `policy_pack: str | None`
  - Config loader accepts `[pack].policy_pack`
  - CLI now supports `--policy-pack`
- Updated runtime policy resolution in `packer.pack()`:
  - Built-in pack rules are combined with explicit `policy_rules` (pack rules first)
  - Unknown pack names and invalid combined policy configs fail with a clear `Exit(code=1)` path
- Added integration fixtures and snapshot assertions proving pack behavior differences:
  - New fixture corpus under `tests/integration/fixtures/policy_pack_corpus/`
  - Snapshot file: `tests/integration/fixtures/expected/policy_pack_deltas.json`
  - Integration test: `tests/integration/test_policy_packs.py`
  - Fast guard: `tests/test_snapshot_guard.py`
- Updated README documentation:
  - `--policy-pack` usage
  - pack intents/tradeoffs
  - `foldermix.toml` config example

## Validation
- `ruff check .`
- `ruff format --check .`
- `pytest --cov=foldermix --cov-branch --cov-report=term-missing:skip-covered tests/ -o addopts=`
  - Result: `272 passed, 1 skipped`
  - Coverage: `99%`
- Targeted integration test:
  - `pytest tests/integration/test_policy_packs.py -m integration -o addopts=`

## Notes
- This PR intentionally keeps policy packs as built-in, versioned definitions (no pack authoring UX) to match the issue scope.
- Existing custom `policy_rules` behavior remains supported and now composes with pack defaults.