### PR TITLE
Release: bump version to 0.1.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "foldermix"
-version = "0.1.9"
+version = "0.1.10"
 description = "Pack a folder into a single LLM-friendly context file"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/integration/fixtures/expected/simple_project.jsonl
+++ b/tests/integration/fixtures/expected/simple_project.jsonl
@@ -1,4 +1,4 @@
-{"type": "header", "root": "__ROOT__", "generated_at": "2024-01-02T00:00:00+00:00", "version": "0.1.9", "file_count": 3, "total_bytes": 32, "args": {}}
+{"type": "header", "root": "__ROOT__", "generated_at": "2024-01-02T00:00:00+00:00", "version": "0.1.10", "file_count": 3, "total_bytes": 32, "args": {}}
 {"type": "file", "path": "alpha.md", "ext": ".md", "size_bytes": 8, "mtime": "2024-01-01T00:00:00+00:00", "sha256": null, "converter": "text", "original_mime": "text/md", "warnings": [], "warning_entries": [], "truncated": false, "content": "# Alpha\n"}
 {"type": "file", "path": "code.py", "ext": ".py", "size_bytes": 12, "mtime": "2024-01-01T00:00:00+00:00", "sha256": null, "converter": "text", "original_mime": "text/py", "warnings": [], "warning_entries": [], "truncated": false, "content": "print(\"hi\")\n"}
 {"type": "file", "path": "nested/note.txt", "ext": ".txt", "size_bytes": 12, "mtime": "2024-01-01T00:00:00+00:00", "sha256": null, "converter": "text", "original_mime": "text/txt", "warnings": [], "warning_entries": [], "truncated": false, "content": "line1\nline2\n"}

--- a/tests/integration/fixtures/expected/simple_project.md
+++ b/tests/integration/fixtures/expected/simple_project.md
@@ -2,7 +2,7 @@
 
 - **Root**: `__ROOT__`
 - **Generated**: 2024-01-02T00:00:00+00:00
-- **Version**: 0.1.9
+- **Version**: 0.1.10
 - **Files**: 3
 - **Total bytes**: 32
 

--- a/tests/integration/fixtures/expected/simple_project.xml
+++ b/tests/integration/fixtures/expected/simple_project.xml
@@ -3,7 +3,7 @@
   <header>
     <root>__ROOT__</root>
     <generated_at>2024-01-02T00:00:00+00:00</generated_at>
-    <version>0.1.9</version>
+    <version>0.1.10</version>
     <file_count>3</file_count>
     <total_bytes>32</total_bytes>
   </header>


### PR DESCRIPTION
## Summary
Prepare the `0.1.10` release.

## Changes
- Bump package version in `pyproject.toml`:
  - `0.1.9` -> `0.1.10`
- Update versioned integration snapshot fixtures that embed the package version:
  - `tests/integration/fixtures/expected/simple_project.md`
  - `tests/integration/fixtures/expected/simple_project.jsonl`
  - `tests/integration/fixtures/expected/simple_project.xml`

## Why fixture updates are included
The expected snapshot headers include `foldermix.__version__`; release bumps must update these fixtures to keep snapshot guard and integration tests consistent.

## Local validation
- `PYENV_VERSION=foldermix pytest -o addopts= tests/test_version_module.py tests/test_snapshot_guard.py`
- `PYENV_VERSION=foldermix pytest -o addopts= tests/integration/test_pack_outputs.py tests/integration/test_pack_outputs_structured.py -m integration`
- `PYENV_VERSION=foldermix pytest -m "not integration and not slow" -o addopts=`

## Release behavior on merge
Merging this PR to `main` should trigger the release automation path that detects the version bump and runs publish/update jobs.