### PR TITLE
Handle inaccessible Homebrew tap repo gracefully in release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,8 +319,12 @@ jobs:
           TAP_REMOTE_URL: https://x-access-token:${{ env.HOMEBREW_TAP_GITHUB_TOKEN }}@github.com/${{ env.TAP_REPOSITORY }}.git
         run: |
           set -euo pipefail
-          tap_head="$(git ls-remote --symref "${TAP_REMOTE_URL}" HEAD 2>/dev/null || true)"
-          if [ -z "${tap_head}" ]; then
+          set +e
+          tap_head="$(git ls-remote --symref "${TAP_REMOTE_URL}" HEAD 2>/dev/null)"
+          ls_remote_status=$?
+          set -e
+
+          if [ "${ls_remote_status}" -ne 0 ]; then
             echo "::warning::Tap repository ${TAP_REPOSITORY} is not accessible with HOMEBREW_TAP_GITHUB_TOKEN; skipping tap update."
             echo "tap_repo_accessible=false" >> "$GITHUB_OUTPUT"
             echo "tap_repo_has_branch=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- make `update-homebrew-tap` resilient when the configured tap repository is inaccessible (missing repo / missing token access)
- prevent release workflow failure in that case

## Root cause
In run `22710781353` job `65848983130`, `Detect tap branch` failed with:
- `remote: Repository not found.`
- `fatal: repository 'https://github.com/foldermix/homebrew-foldermix.git/' not found`

The step exited non-zero and failed the workflow.

## Changes
- `update-homebrew-tap` job now exports `tap_repo_accessible` output from `tap_repo_ref`.
- `Detect tap branch`:
  - probes remote with `git ls-remote --symref ... || true`
  - when inaccessible, emits warning and sets:
    - `tap_repo_accessible=false`
    - `tap_repo_has_branch=false`
    - `tap_branch=main`
  - exits successfully (skip path)
- added explicit skip step for inaccessible tap repository.
- gated `Checkout tap repository` and `Update tap formula and push` on `tap_repo_accessible == 'true'`.
- gated `release-consumer-smoke-homebrew` on `needs.update-homebrew-tap.outputs.tap_repo_accessible == 'true'`.

## Expected behavior
- If token/repo access is valid: tap update and Homebrew smoke proceed normally.
- If token/repo access is invalid: tap update + Homebrew smoke are skipped with warnings, and release workflow does not fail because of tap access misconfiguration.