### PR TITLE
Revert tap-inaccessible skip; fail release when tap update cannot run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,7 +282,6 @@ jobs:
     needs: [publish-pypi]
     outputs:
       tap_update_enabled: ${{ steps.tap_guard.outputs.tap_update_enabled }}
-      tap_repo_accessible: ${{ steps.tap_repo_ref.outputs.tap_repo_accessible }}
     permissions:
       contents: read
     env:
@@ -319,21 +318,7 @@ jobs:
           TAP_REMOTE_URL: https://x-access-token:${{ env.HOMEBREW_TAP_GITHUB_TOKEN }}@github.com/${{ env.TAP_REPOSITORY }}.git
         run: |
           set -euo pipefail
-          set +e
-          tap_head="$(git ls-remote --symref "${TAP_REMOTE_URL}" HEAD 2>/dev/null)"
-          ls_remote_status=$?
-          set -e
-
-          if [ "${ls_remote_status}" -ne 0 ]; then
-            echo "::warning::Tap repository ${TAP_REPOSITORY} is not accessible with HOMEBREW_TAP_GITHUB_TOKEN; skipping tap update."
-            echo "tap_repo_accessible=false" >> "$GITHUB_OUTPUT"
-            echo "tap_repo_has_branch=false" >> "$GITHUB_OUTPUT"
-            echo "tap_branch=main" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "tap_repo_accessible=true" >> "$GITHUB_OUTPUT"
-          branch="$(printf "%s\n" "${tap_head}" | awk '/^ref:/ {sub("refs/heads/","",$2); print $2; exit}')"
+          branch="$(git ls-remote --symref "${TAP_REMOTE_URL}" HEAD | awk '/^ref:/ {sub("refs/heads/","",$2); print $2; exit}')"
           if [ -n "${branch}" ] && git ls-remote --heads "${TAP_REMOTE_URL}" "${branch}" | grep -q .; then
             echo "tap_repo_has_branch=true" >> "$GITHUB_OUTPUT"
             echo "tap_branch=${branch}" >> "$GITHUB_OUTPUT"
@@ -341,15 +326,9 @@ jobs:
             echo "tap_repo_has_branch=false" >> "$GITHUB_OUTPUT"
             echo "tap_branch=main" >> "$GITHUB_OUTPUT"
           fi
-      - name: Skip tap update (repository inaccessible)
-        if: >-
-          steps.tap_guard.outputs.tap_update_enabled == 'true' &&
-          steps.tap_repo_ref.outputs.tap_repo_accessible != 'true'
-        run: echo "Tap repository is not accessible with current token; skipping tap update."
       - name: Checkout tap repository
         if: >-
           steps.tap_guard.outputs.tap_update_enabled == 'true' &&
-          steps.tap_repo_ref.outputs.tap_repo_accessible == 'true' &&
           steps.tap_repo_ref.outputs.tap_repo_has_branch == 'true'
         uses: actions/checkout@v4
         with:
@@ -358,9 +337,7 @@ jobs:
           path: homebrew-tap
           ref: ${{ steps.tap_repo_ref.outputs.tap_branch }}
       - name: Update tap formula and push
-        if: >-
-          steps.tap_guard.outputs.tap_update_enabled == 'true' &&
-          steps.tap_repo_ref.outputs.tap_repo_accessible == 'true'
+        if: steps.tap_guard.outputs.tap_update_enabled == 'true'
         env:
           TAP_REMOTE_URL: https://x-access-token:${{ env.HOMEBREW_TAP_GITHUB_TOKEN }}@github.com/${{ env.TAP_REPOSITORY }}.git
           TAP_BRANCH: ${{ steps.tap_repo_ref.outputs.tap_branch }}
@@ -493,8 +470,7 @@ jobs:
       github.event_name == 'push' &&
       github.ref == 'refs/heads/main' &&
       needs.publish-pypi.outputs.should_publish == 'true' &&
-      needs.update-homebrew-tap.outputs.tap_update_enabled == 'true' &&
-      needs.update-homebrew-tap.outputs.tap_repo_accessible == 'true'
+      needs.update-homebrew-tap.outputs.tap_update_enabled == 'true'
     runs-on: macos-latest
     needs: [publish-pypi, update-homebrew-tap]
     permissions:


### PR DESCRIPTION
## Summary
- reverts the recent behavior that allowed `update-homebrew-tap` to pass when tap repository access was unavailable
- restores fail-fast behavior so release CI fails if tap update cannot execute

## What was reverted
In `.github/workflows/ci.yml`:
- removed `tap_repo_accessible` job output
- removed graceful skip path for inaccessible tap repository
- removed extra gating on `tap_repo_accessible` for checkout/push and Homebrew consumer smoke job
- restored direct `git ls-remote --symref ...` branch detection under `set -euo pipefail` so inaccessible tap repo/token causes step failure

## Intent
- enforce that release automation surfaces tap-update misconfiguration as a hard CI failure rather than a warning/skip.