### PR TITLE
Bump version to 0.1.15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "foldermix"
-version = "0.1.14"
+version = "0.1.15"
 description = "Pack a folder into a single LLM-friendly context file"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/integration/fixtures/expected/simple_project.jsonl
+++ b/tests/integration/fixtures/expected/simple_project.jsonl
@@ -1,4 +1,4 @@
-{"type": "header", "root": "__ROOT__", "generated_at": "2024-01-02T00:00:00+00:00", "version": "0.1.14", "file_count": 3, "total_bytes": 32, "args": {}}
+{"type": "header", "root": "__ROOT__", "generated_at": "2024-01-02T00:00:00+00:00", "version": "0.1.15", "file_count": 3, "total_bytes": 32, "args": {}}
 {"type": "file", "path": "alpha.md", "ext": ".md", "size_bytes": 8, "mtime": "2024-01-01T00:00:00+00:00", "sha256": null, "converter": "text", "original_mime": "text/md", "warnings": [], "warning_entries": [], "truncated": false, "content": "# Alpha\n"}
 {"type": "file", "path": "code.py", "ext": ".py", "size_bytes": 12, "mtime": "2024-01-01T00:00:00+00:00", "sha256": null, "converter": "text", "original_mime": "text/py", "warnings": [], "warning_entries": [], "truncated": false, "content": "print(\"hi\")\n"}
 {"type": "file", "path": "nested/note.txt", "ext": ".txt", "size_bytes": 12, "mtime": "2024-01-01T00:00:00+00:00", "sha256": null, "converter": "text", "original_mime": "text/txt", "warnings": [], "warning_entries": [], "truncated": false, "content": "line1\nline2\n"}

--- a/tests/integration/fixtures/expected/simple_project.md
+++ b/tests/integration/fixtures/expected/simple_project.md
@@ -2,7 +2,7 @@
 
 - **Root**: `__ROOT__`
 - **Generated**: 2024-01-02T00:00:00+00:00
-- **Version**: 0.1.14
+- **Version**: 0.1.15
 - **Files**: 3
 - **Total bytes**: 32
 

--- a/tests/integration/fixtures/expected/simple_project.xml
+++ b/tests/integration/fixtures/expected/simple_project.xml
@@ -3,7 +3,7 @@
   <header>
     <root>__ROOT__</root>
     <generated_at>2024-01-02T00:00:00+00:00</generated_at>
-    <version>0.1.14</version>
+    <version>0.1.15</version>
     <file_count>3</file_count>
     <total_bytes>32</total_bytes>
   </header>


### PR DESCRIPTION
## Summary
- Bump package version from `0.1.14` to `0.1.15`.
- Update version-bearing integration fixtures to keep snapshot tests aligned.

## Files Updated
- `pyproject.toml`
- `tests/integration/fixtures/expected/simple_project.md`
- `tests/integration/fixtures/expected/simple_project.xml`
- `tests/integration/fixtures/expected/simple_project.jsonl`

## Why
Merging this PR updates `[project].version` on `main`, which triggers the release pipeline in CI.

## Local Validation
- `UV_PYTHON=3.12 uv run python -m pytest -o addopts= -o filterwarnings="ignore::pytest.PytestConfigWarning" tests/test_snapshot_guard.py tests/integration/test_pack_outputs.py tests/integration/test_pack_outputs_structured.py`
- Result: `6 passed`