### PR TITLE
chore(release): bump version to 0.1.18

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "foldermix"
-version = "0.1.17"
+version = "0.1.18"
 description = "Pack a folder into a single LLM-friendly context file"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/integration/fixtures/expected/simple_project.jsonl
+++ b/tests/integration/fixtures/expected/simple_project.jsonl
@@ -1,4 +1,4 @@
-{"type": "header", "root": "__ROOT__", "generated_at": "2024-01-02T00:00:00+00:00", "version": "0.1.17", "file_count": 3, "total_bytes": 32, "args": {}}
+{"type": "header", "root": "__ROOT__", "generated_at": "2024-01-02T00:00:00+00:00", "version": "0.1.18", "file_count": 3, "total_bytes": 32, "args": {}}
 {"type": "file", "path": "alpha.md", "ext": ".md", "size_bytes": 8, "mtime": "2024-01-01T00:00:00+00:00", "sha256": null, "converter": "text", "original_mime": "text/md", "warnings": [], "warning_entries": [], "truncated": false, "content": "# Alpha\n"}
 {"type": "file", "path": "code.py", "ext": ".py", "size_bytes": 12, "mtime": "2024-01-01T00:00:00+00:00", "sha256": null, "converter": "text", "original_mime": "text/py", "warnings": [], "warning_entries": [], "truncated": false, "content": "print(\"hi\")\n"}
 {"type": "file", "path": "nested/note.txt", "ext": ".txt", "size_bytes": 12, "mtime": "2024-01-01T00:00:00+00:00", "sha256": null, "converter": "text", "original_mime": "text/txt", "warnings": [], "warning_entries": [], "truncated": false, "content": "line1\nline2\n"}

--- a/tests/integration/fixtures/expected/simple_project.md
+++ b/tests/integration/fixtures/expected/simple_project.md
@@ -2,7 +2,7 @@
 
 - **Root**: `__ROOT__`
 - **Generated**: 2024-01-02T00:00:00+00:00
-- **Version**: 0.1.17
+- **Version**: 0.1.18
 - **Files**: 3
 - **Total bytes**: 32
 

--- a/tests/integration/fixtures/expected/simple_project.xml
+++ b/tests/integration/fixtures/expected/simple_project.xml
@@ -3,7 +3,7 @@
   <header>
     <root>__ROOT__</root>
     <generated_at>2024-01-02T00:00:00+00:00</generated_at>
-    <version>0.1.17</version>
+    <version>0.1.18</version>
     <file_count>3</file_count>
     <total_bytes>32</total_bytes>
   </header>


### PR DESCRIPTION
## Summary
- bump the package version from `0.1.17` to `0.1.18`
- update the expected integration output fixtures to the new embedded version
- keep the release PR scoped to the versioned artifacts that trigger publish/release automation

## Validation
- `/Users/shaypalachy/clones/foldermix/.venv/bin/pytest -o addopts= tests/test_version_module.py tests/test_snapshot_guard.py tests/integration/test_pack_outputs.py tests/integration/test_pack_outputs_structured.py`
  - `8 passed`

## Notes
- Branch was cut from current `main` after PR #95 merged.
- Fixture updates are included in the same PR so the snapshot/version checks stay green.