### PR TITLE
fix(pdf): improve Hebrew/RTL native-text extraction

### DIFF
--- a/foldermix/converters/pdf_fallback.py
+++ b/foldermix/converters/pdf_fallback.py
@@ -103,8 +103,11 @@ class PdfFallbackConverter:
                 check=True,
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=60,
             )
-        except (OSError, subprocess.CalledProcessError):
+        except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
             return None
 
         raw_pages = completed.stdout.split("\f")

--- a/tests/integration/test_converters_noisy_real_files.py
+++ b/tests/integration/test_converters_noisy_real_files.py
@@ -85,8 +85,6 @@ def test_noisy_pdf_hebrew_rtl_extraction_quality() -> None:
     assert "שי פלצ'י אפק" in result.content
     assert "nop@chau.ac.jl" in result.content
     assert result.converter_name == "pdftotext"
-    assert "Text Mining" in result.content
-    assert "דרישות קדם" in result.content
     assert "דרישות קדם" in result.content.split("Text Mining", 1)[1]
     assert "ם:דרישות קד" not in result.content
 

--- a/tests/test_converters_fallback.py
+++ b/tests/test_converters_fallback.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import subprocess
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -283,8 +284,10 @@ def test_pdf_fallback_prefers_pdftotext_for_rtl_native_text(monkeypatch, tmp_pat
     monkeypatch.setattr(
         "foldermix.converters.pdf_fallback.shutil.which", lambda exe: "/usr/bin/pdftotext"
     )
+    run_kwargs = {}
 
     def _run(*_args, **_kwargs):
+        run_kwargs.update(_kwargs)
         return SimpleNamespace(stdout="\u202bכריית טקסט\u202c\n\u202bדרישות קדם\u202c\f")
 
     monkeypatch.setattr("foldermix.converters.pdf_fallback.subprocess.run", _run)
@@ -293,6 +296,9 @@ def test_pdf_fallback_prefers_pdftotext_for_rtl_native_text(monkeypatch, tmp_pat
     assert result.content == "### Page 1\nכריית טקסט\nדרישות קדם"
     assert result.converter_name == "pdftotext"
     assert result.warnings == []
+    assert run_kwargs["encoding"] == "utf-8"
+    assert run_kwargs["errors"] == "replace"
+    assert run_kwargs["timeout"] == 60
 
 
 def test_pdf_fallback_clean_poppler_page_text_strips_controls_and_blank_edges() -> None:
@@ -314,6 +320,24 @@ def test_pdf_fallback_extract_poppler_pages_returns_none_on_subprocess_failure(
 
     def _run(*_args, **_kwargs):
         raise OSError("boom")
+
+    monkeypatch.setattr("foldermix.converters.pdf_fallback.subprocess.run", _run)
+
+    assert PdfFallbackConverter._extract_poppler_pages(path) is None
+
+
+def test_pdf_fallback_extract_poppler_pages_returns_none_on_timeout(
+    monkeypatch, tmp_path: Path
+) -> None:
+    path = tmp_path / "f.pdf"
+    path.write_text("placeholder", encoding="utf-8")
+
+    monkeypatch.setattr(
+        "foldermix.converters.pdf_fallback.shutil.which", lambda exe: "/usr/bin/pdftotext"
+    )
+
+    def _run(*_args, **_kwargs):
+        raise subprocess.TimeoutExpired(cmd="pdftotext", timeout=60)
 
     monkeypatch.setattr("foldermix.converters.pdf_fallback.subprocess.run", _run)
 


### PR DESCRIPTION
## Summary
Fixes #99.

Improve the PDF fallback for native-text Hebrew/RTL documents by preferring `pdftotext -layout` when the document contains RTL text and the Poppler tool is available. This preserves much better logical ordering and table-like structure than the existing `pypdf` native extraction on the noisy syllabus fixture.

## What changed
- add RTL-text detection in `PdfFallbackConverter`
- add an alternate native extraction path via `pdftotext -layout`
- strip bidi/control characters from Poppler output before emitting page text
- keep `pypdf` as the default path for non-RTL/simple Latin PDFs
- fall back to `pypdf` automatically when `pdftotext` is unavailable or fails
- promote the noisy Hebrew PDF integration test from `xfail` to a passing assertion when `pdftotext` is present
- add unit coverage for:
  - Poppler preference for RTL native text
  - fallback when Poppler is unavailable
  - control-character cleanup
  - Poppler subprocess failure handling
  - preserving a non-empty last page when there is no trailing form-feed
  - missing `PdfFallbackConverter.can_convert()` coverage

## Validation
- `uv run pytest -o addopts= tests/test_converters_fallback.py tests/integration/test_converters_noisy_real_files.py -k 'pdf or noisy_pdf'`
- `uv run pytest -o addopts= --cov=foldermix.converters.pdf_fallback --cov-branch --cov-report=term-missing tests/test_converters_fallback.py tests/integration/test_converters_noisy_real_files.py`
  - `foldermix/converters/pdf_fallback.py`: `100%`
- `uv run ruff check foldermix/converters/pdf_fallback.py tests/test_converters_fallback.py tests/integration/test_converters_noisy_real_files.py`
- `uv run ruff format --check foldermix/converters/pdf_fallback.py tests/test_converters_fallback.py tests/integration/test_converters_noisy_real_files.py`

## Notes
- This intentionally does not add a new Python dependency.
- The improved RTL path is opportunistic: if `pdftotext` is not installed, behavior falls back to the existing `pypdf` path rather than failing conversion.
- Existing Latin/simple PDF behavior remains on `pypdf` unless the document is detected as RTL-heavy.