### PR TITLE
Add PR agent context refresh workflow

### DIFF
--- a/.github/workflows/pr-agent-context-refresh.yml
+++ b/.github/workflows/pr-agent-context-refresh.yml
@@ -5,37 +5,35 @@ on:
     types: [submitted, edited, dismissed]
   pull_request_review_comment:
     types: [created, edited, deleted]
-  check_run:
+  check_suite:
     types: [completed]
 
 concurrency:
   group: >-
     ${{ github.workflow }}-${{
       github.event.pull_request.number ||
-      github.event.check_run.pull_requests[0].number ||
-      github.event.check_run.head_sha ||
+      github.event.check_suite.pull_requests[0].number ||
+      github.event.check_suite.head_sha ||
       github.sha
     }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-  actions: read
-  pull-requests: write
-
 jobs:
   pr-agent-context-refresh:
     name: PR agent context refresh
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: write
     if: >-
       (github.event_name == 'pull_request_review' &&
        github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.event_name == 'pull_request_review_comment' &&
        github.event.pull_request.head.repo.full_name == github.repository) ||
-      (github.event_name == 'check_run' &&
+      (github.event_name == 'check_suite' &&
        github.event.action == 'completed' &&
-       github.event.check_run.app.slug != 'github-actions' &&
-       toJson(github.event.check_run.pull_requests) != '[]' &&
-       github.event.check_run.pull_requests[0].head.repo.full_name == github.repository)
+       github.event.check_suite.app.slug != 'github-actions' &&
+       toJson(github.event.check_suite.pull_requests) != '[]')
     uses: shaypal5/pr-agent-context/.github/workflows/pr-agent-context.yml@v4
     with:
       tool_ref: v4
@@ -51,4 +49,4 @@ jobs:
       enable_cross_run_coverage_lookup: true
       coverage_source_workflows: CI
       prompt_template_file: .github/pr-agent-context-template.md
-      debug_artifacts: true
+      debug_artifacts: false


### PR DESCRIPTION
## Summary
- add a dedicated `pr-agent-context-refresh` workflow for later PR signals
- rerun `pr-agent-context` on review activity and completed non-Actions check runs
- keep refresh comments scoped and suppress no-op all-clear refresh comments

## Why
PR #126 showed that the initial `pull_request`-triggered `pr-agent-context` run can miss later signals such as Copilot review comments because the repo had no refresh workflow to rerun after those signals arrive.

## Notes
- this follows the current recommended refresh pattern from `pr-agent-context`
- it reuses the existing raw coverage artifacts from the `CI` workflow via `coverage_source_workflows: CI`
- it does not change the main CI producer workflow itself

## Validation
- loaded the new workflow with PyYAML `BaseLoader` and verified the key trigger and `execution_mode: refresh` fields