### PR TITLE
Use coverage.xml artifacts for PR agent context

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,13 +196,12 @@ jobs:
         run: pip install -e ".[dev,all]"
       - name: Full Test Suite (Coverage Gate)
         run: python -m pytest --cov=foldermix --cov-report=xml
-      - name: Upload raw coverage data
+      - name: Upload coverage XML artifact
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: pr-agent-context-coverage-ubuntu-latest-py3.12
-          path: .coverage*
-          include-hidden-files: true
+          name: coverage-xml
+          path: coverage.xml
           if-no-files-found: ignore
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
@@ -227,7 +226,9 @@ jobs:
       include_review_comments: true
       include_failing_checks: true
       include_patch_coverage: true
-      coverage_artifact_prefix: pr-agent-context-coverage
+      patch_coverage_source_mode: coverage_xml_artifact
+      coverage_report_artifact_name: coverage-xml
+      coverage_report_filename: coverage.xml
       prompt_template_file: .github/pr-agent-context-template.md
       debug_artifacts: true
 

--- a/.github/workflows/pr-agent-context-refresh.yml
+++ b/.github/workflows/pr-agent-context-refresh.yml
@@ -45,7 +45,9 @@ jobs:
       include_failing_checks: true
       include_patch_coverage: true
       wait_for_reviews_to_settle: true
-      coverage_artifact_prefix: pr-agent-context-coverage
+      patch_coverage_source_mode: coverage_xml_artifact
+      coverage_report_artifact_name: coverage-xml
+      coverage_report_filename: coverage.xml
       enable_cross_run_coverage_lookup: true
       coverage_source_workflows: CI
       prompt_template_file: .github/pr-agent-context-template.md


### PR DESCRIPTION
## Summary
- upload the combined coverage.xml file as a CI artifact
- switch both the CI and refresh pr-agent-context runs to coverage_xml_artifact mode
- stop feeding pr-agent-context raw .coverage artifacts in foldermix

## Why
This makes pr-agent-context compute patch coverage from the same combined XML report produced by the full coverage job, which avoids the false 0% refresh comments we were seeing from cross-run raw coverage reconstruction.
