### PR TITLE
Serialize OCR-native conversions and bump version to 0.1.23

### DIFF
--- a/foldermix/packer.py
+++ b/foldermix/packer.py
@@ -54,6 +54,14 @@ _STRUCTURED_TRUNCATE_AFTER_CONVERT_EXTS = {
 }
 
 
+def _requires_serial_conversion(record: FileRecord, config: PackConfig) -> bool:
+    if record.ext == ".pdf" and config.pdf_ocr:
+        return True
+    if record.ext in IMAGE_OCR_EXTENSIONS and config.image_ocr:
+        return True
+    return False
+
+
 def _count_failing_policy_findings(
     policy_findings: list[dict[str, object]], *, min_severity: str
 ) -> int:
@@ -597,18 +605,43 @@ def pack(config: PackConfig) -> None:
         except Exception as e:
             return record, e
 
-    if use_progress and has_tqdm:
-        from tqdm import tqdm
+    parallel_records = [
+        record for record in included if not _requires_serial_conversion(record, config)
+    ]
+    serial_records = [record for record in included if _requires_serial_conversion(record, config)]
 
-        with ThreadPoolExecutor(max_workers=config.workers) as executor:
-            futures = {executor.submit(convert_with_idx, r): r for r in included}
-            results = []
-            for future in tqdm(as_completed(futures), total=len(included), desc="Converting"):
-                results.append(future.result())
-    else:
-        with ThreadPoolExecutor(max_workers=config.workers) as executor:
-            futures = {executor.submit(convert_with_idx, r): r for r in included}
-            results = [f.result() for f in as_completed(futures)]
+    results: list[tuple[FileRecord, FileBundleItem | Exception]] = []
+
+    with ThreadPoolExecutor(max_workers=config.workers) as executor:
+        futures = [executor.submit(convert_with_idx, r) for r in parallel_records]
+
+        if serial_records:
+            if use_progress and has_tqdm:
+                from tqdm import tqdm
+
+                serial_iter = tqdm(
+                    serial_records,
+                    total=len(serial_records),
+                    desc="Converting OCR/native files",
+                )
+            else:
+                serial_iter = serial_records
+
+            for record in serial_iter:
+                results.append(convert_with_idx(record))
+
+        future_iter = as_completed(futures)
+        if use_progress and has_tqdm:
+            from tqdm import tqdm
+
+            future_iter = tqdm(
+                future_iter,
+                total=len(parallel_records),
+                desc="Converting",
+            )
+
+        for future in future_iter:
+            results.append(future.result())
 
     # Re-sort to maintain deterministic order
     record_to_item: dict[str, FileBundleItem | Exception] = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "foldermix"
-version = "0.1.22"
+version = "0.1.23"
 description = "Pack a folder into a single LLM-friendly context file"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/integration/fixtures/expected/simple_project.jsonl
+++ b/tests/integration/fixtures/expected/simple_project.jsonl
@@ -1,4 +1,4 @@
-{"type": "header", "root": "__ROOT__", "generated_at": "2024-01-02T00:00:00+00:00", "version": "0.1.22", "file_count": 3, "total_bytes": 32, "args": {}}
+{"type": "header", "root": "__ROOT__", "generated_at": "2024-01-02T00:00:00+00:00", "version": "0.1.23", "file_count": 3, "total_bytes": 32, "args": {}}
 {"type": "file", "path": "alpha.md", "ext": ".md", "size_bytes": 8, "mtime": "2024-01-01T00:00:00+00:00", "sha256": null, "converter": "text", "original_mime": "text/md", "warnings": [], "warning_entries": [], "truncated": false, "content": "# Alpha\n"}
 {"type": "file", "path": "code.py", "ext": ".py", "size_bytes": 12, "mtime": "2024-01-01T00:00:00+00:00", "sha256": null, "converter": "text", "original_mime": "text/py", "warnings": [], "warning_entries": [], "truncated": false, "content": "print(\"hi\")\n"}
 {"type": "file", "path": "nested/note.txt", "ext": ".txt", "size_bytes": 12, "mtime": "2024-01-01T00:00:00+00:00", "sha256": null, "converter": "text", "original_mime": "text/txt", "warnings": [], "warning_entries": [], "truncated": false, "content": "line1\nline2\n"}

--- a/tests/integration/fixtures/expected/simple_project.md
+++ b/tests/integration/fixtures/expected/simple_project.md
@@ -2,7 +2,7 @@
 
 - **Root**: `__ROOT__`
 - **Generated**: 2024-01-02T00:00:00+00:00
-- **Version**: 0.1.22
+- **Version**: 0.1.23
 - **Files**: 3
 - **Total bytes**: 32
 

--- a/tests/integration/fixtures/expected/simple_project.xml
+++ b/tests/integration/fixtures/expected/simple_project.xml
@@ -3,7 +3,7 @@
   <header>
     <root>__ROOT__</root>
     <generated_at>2024-01-02T00:00:00+00:00</generated_at>
-    <version>0.1.22</version>
+    <version>0.1.23</version>
     <file_count>3</file_count>
     <total_bytes>32</total_bytes>
   </header>

--- a/tests/test_packer.py
+++ b/tests/test_packer.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import json
+import sys
 import time
 from pathlib import Path
+from threading import Event, current_thread
+from types import SimpleNamespace
 
 import pytest
 import typer
@@ -969,6 +972,128 @@ def test_pack_keeps_deterministic_order_after_parallel_conversion(
     packer.pack(config)
 
     assert captured_order == ["a.txt", "b.txt"]
+
+
+def test_requires_serial_conversion_for_ocr_native_paths(tmp_path: Path) -> None:
+    pdf_path = tmp_path / "doc.pdf"
+    image_path = tmp_path / "scan.jpg"
+    text_path = tmp_path / "note.txt"
+    _write(pdf_path, "pdf")
+    _write(image_path, "jpg")
+    _write(text_path, "txt")
+
+    assert packer._requires_serial_conversion(
+        _record(pdf_path), PackConfig(root=tmp_path, pdf_ocr=True)
+    )
+    assert packer._requires_serial_conversion(
+        _record(image_path),
+        PackConfig(root=tmp_path, include_ext=[".jpg"], image_ocr=True),
+    )
+    assert not packer._requires_serial_conversion(_record(text_path), PackConfig(root=tmp_path))
+
+
+def test_pack_runs_ocr_native_paths_outside_thread_pool(tmp_path: Path, monkeypatch) -> None:
+    _write(tmp_path / "note.txt", "txt")
+    _write(tmp_path / "doc.pdf", "pdf")
+
+    seen_threads: dict[str, str] = {}
+    parallel_started = Event()
+    serial_started = Event()
+
+    def fake_convert_record(record: FileRecord, registry, config: PackConfig) -> FileBundleItem:
+        seen_threads[record.relpath] = current_thread().name
+        if record.relpath == "note.txt":
+            parallel_started.set()
+            seen_threads["note_wait_saw_serial"] = str(serial_started.wait(timeout=0.5))
+        elif record.relpath == "doc.pdf":
+            seen_threads["serial_saw_parallel"] = str(parallel_started.wait(timeout=0.5))
+            serial_started.set()
+        return FileBundleItem(
+            relpath=record.relpath,
+            ext=record.ext,
+            size_bytes=record.size,
+            mtime="2026-03-22T00:00:00Z",
+            sha256=None,
+            content=record.relpath,
+            converter_name="fake",
+            original_mime="text/plain",
+            warnings=[],
+            warning_entries=[],
+            truncated=False,
+            redacted=False,
+            redaction_mode=config.redact,
+            redaction_event_count=0,
+            redaction_categories=[],
+        )
+
+    monkeypatch.setattr(packer, "_convert_record", fake_convert_record)
+
+    config = PackConfig(
+        root=tmp_path,
+        out=tmp_path / "out.md",
+        format="md",
+        workers=2,
+        include_ext=[".txt", ".pdf"],
+        include_sha256=False,
+        pdf_ocr=True,
+    )
+
+    packer.pack(config)
+
+    assert seen_threads["doc.pdf"] == "MainThread"
+    assert seen_threads["note.txt"] != "MainThread"
+    assert seen_threads["serial_saw_parallel"] == "True"
+    assert seen_threads["note_wait_saw_serial"] == "True"
+
+
+def test_pack_progress_handles_serial_ocr_records(tmp_path: Path, monkeypatch) -> None:
+    _write(tmp_path / "note.txt", "txt")
+    _write(tmp_path / "doc.pdf", "pdf")
+
+    progress_calls: list[tuple[int, str]] = []
+
+    def fake_tqdm(iterable, total: int, desc: str):
+        progress_calls.append((total, desc))
+        return iterable
+
+    monkeypatch.setitem(sys.modules, "tqdm", SimpleNamespace(tqdm=fake_tqdm))
+
+    def fake_convert_record(record: FileRecord, registry, config: PackConfig) -> FileBundleItem:
+        return FileBundleItem(
+            relpath=record.relpath,
+            ext=record.ext,
+            size_bytes=record.size,
+            mtime="2026-03-22T00:00:00Z",
+            sha256=None,
+            content=record.relpath,
+            converter_name="fake",
+            original_mime="text/plain",
+            warnings=[],
+            warning_entries=[],
+            truncated=False,
+            redacted=False,
+            redaction_mode=config.redact,
+            redaction_event_count=0,
+            redaction_categories=[],
+        )
+
+    monkeypatch.setattr(packer, "_convert_record", fake_convert_record)
+
+    config = PackConfig(
+        root=tmp_path,
+        out=tmp_path / "out.md",
+        format="md",
+        workers=2,
+        include_ext=[".txt", ".pdf"],
+        include_sha256=False,
+        pdf_ocr=True,
+        progress=True,
+    )
+
+    packer.pack(config)
+
+    assert (1, "Converting OCR/native files") in progress_calls
+    assert (1, "Converting") in progress_calls
 
 
 def test_pack_include_toc_false_omits_table_of_contents(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- run PDF OCR and image OCR conversions serially during `pack` instead of sending those native OCR paths through the shared thread pool
- keep non-OCR conversions parallel and add regression tests covering the serial scheduling rule
- bump the package version to `0.1.23` and update the snapshot fixture headers so merge-to-main triggers a release

## Motivation
A user hit a native crash during `foldermix pack` while processing OCR/native files:

```text
Ignoring wrong pointing object 30 0 (offset 0)
python3 ... malloc: Heap corruption detected, free list is damaged
```

This points to native PDF/OCR dependencies rather than a Python exception. Serializing those conversion paths avoids concurrent use of the risky native stack while preserving parallel conversion for regular files.

## Validation
- `uv run pytest -q tests/test_packer.py tests/test_packer_edges.py tests/test_converters_fallback.py tests/test_snapshot_guard.py tests/integration/test_pack_outputs.py -o addopts=`
- `109 passed in 0.47s`

## Notes
- The branch contains two commits: the scheduling fix and the version bump.