### PR TITLE
Add core VTT support

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ foldermix version
 - **Smart filtering**: gitignore support, extension filters, glob patterns
 - **Sensitive file protection**: Automatically skips `.env`, keys, certificates
 - **Optional converters**: PDF (pypdf), OCR-enhanced PDF fallback (rapidocr + pypdfium2), Office docs (python-docx, openpyxl, python-pptx), markitdown
+- **Core text-like formats**: plain text, markup, config/data files, and WebVTT (`.vtt`) via the built-in text converter
 - **Notebook support**: built-in `.ipynb` conversion, with `--ipynb-include-outputs` to include or omit cell outputs
 - **Spreadsheet noise reduction**: XLSX fallback skips low-signal `Copy of ...` tabs by default
 - **Optional duplicate suppression**: skip later files whose content exactly matches an earlier included file
@@ -223,7 +224,7 @@ foldermix init --profile course-refresh --out foldermix.toml --force
 foldermix pack ./previous-course --config foldermix.toml --format md --out course-refresh-context.md --report course-refresh-report.json
 ```
 
-The `course-refresh` profile keeps teaching-material formats broad (`pdf`, `docx`, `pptx`, `ipynb`, `xlsx`, text/markup, structured text) while excluding common student/admin paths such as:
+The `course-refresh` profile keeps teaching-material formats broad (`pdf`, `docx`, `pptx`, `ipynb`, `xlsx`, `vtt`, text/markup, structured text) while excluding common student/admin paths such as:
 
 - grades
 - rosters

--- a/foldermix/config.py
+++ b/foldermix/config.py
@@ -21,6 +21,7 @@ DEFAULT_INCLUDE_EXT: list[str] = [
     ".cfg",
     ".csv",
     ".tsv",
+    ".vtt",
     ".sql",
     ".html",
     ".htm",

--- a/foldermix/converters/text.py
+++ b/foldermix/converters/text.py
@@ -21,6 +21,7 @@ TEXT_EXTENSIONS = {
     ".cfg",
     ".csv",
     ".tsv",
+    ".vtt",
     ".sql",
     ".html",
     ".htm",

--- a/foldermix/converters/text.py
+++ b/foldermix/converters/text.py
@@ -75,6 +75,7 @@ class TextConverter:
         from foldermix.utils import read_text_with_fallback
 
         text, enc_used = read_text_with_fallback(path, encoding)
+        ext = path.suffix.lower().lstrip(".") or "plain"
         warnings: list[str] = []
         if enc_used != encoding:
             warnings.append(f"Encoding fallback: used {enc_used!r} instead of {encoding!r}")
@@ -82,5 +83,5 @@ class TextConverter:
             content=text,
             warnings=warnings,
             converter_name="text",
-            original_mime=f"text/{path.suffix.lstrip('.') or 'plain'}",
+            original_mime=f"text/{ext}",
         )

--- a/foldermix/init_profiles.py
+++ b/foldermix/init_profiles.py
@@ -65,7 +65,7 @@ def _build_profile(
     )
 
 
-_LEGAL_EXT = [".txt", ".md", ".pdf", ".docx", ".csv"]
+_LEGAL_EXT = [".txt", ".md", ".pdf", ".docx", ".csv", ".vtt"]
 _RESEARCH_EXT = [
     ".txt",
     ".md",
@@ -75,15 +75,17 @@ _RESEARCH_EXT = [
     ".xlsx",
     ".csv",
     ".tsv",
+    ".vtt",
     ".json",
     ".yaml",
     ".yml",
 ]
-_SUPPORT_EXT = [".txt", ".md", ".json", ".yaml", ".yml", ".csv", ".tsv", ".log"]
+_SUPPORT_EXT = [".txt", ".md", ".json", ".yaml", ".yml", ".csv", ".tsv", ".vtt", ".log"]
 _ENGINEERING_DOCS_EXT = [
     ".md",
     ".rst",
     ".txt",
+    ".vtt",
     ".py",
     ".js",
     ".ts",
@@ -103,6 +105,7 @@ _COURSE_REFRESH_EXT = [
     ".xlsx",
     ".csv",
     ".tsv",
+    ".vtt",
     ".json",
     ".yaml",
     ".yml",

--- a/tests/data/init_profiles/course-refresh.toml
+++ b/tests/data/init_profiles/course-refresh.toml
@@ -5,7 +5,7 @@
 
 # Pack defaults for this profile.
 [pack]
-include_ext = [".txt", ".md", ".rst", ".pdf", ".docx", ".pptx", ".ipynb", ".xlsx", ".csv", ".tsv", ".json", ".yaml", ".yml"]
+include_ext = [".txt", ".md", ".rst", ".pdf", ".docx", ".pptx", ".ipynb", ".xlsx", ".csv", ".tsv", ".vtt", ".json", ".yaml", ".yml"]
 hidden = false
 respect_gitignore = true
 on_oversize = "truncate"
@@ -23,5 +23,5 @@ exclude_glob = ["*[Gg]rade*", "*[Rr]oster*", "*[Rr]esponse*", "*[Ff]eedback*", "
 
 # Stats defaults for this profile.
 [stats]
-include_ext = [".txt", ".md", ".rst", ".pdf", ".docx", ".pptx", ".ipynb", ".xlsx", ".csv", ".tsv", ".json", ".yaml", ".yml"]
+include_ext = [".txt", ".md", ".rst", ".pdf", ".docx", ".pptx", ".ipynb", ".xlsx", ".csv", ".tsv", ".vtt", ".json", ".yaml", ".yml"]
 hidden = false

--- a/tests/data/init_profiles/engineering-docs.toml
+++ b/tests/data/init_profiles/engineering-docs.toml
@@ -5,7 +5,7 @@
 
 # Pack defaults for this profile.
 [pack]
-include_ext = [".md", ".rst", ".txt", ".py", ".js", ".ts", ".json", ".yaml", ".yml", ".toml"]
+include_ext = [".md", ".rst", ".txt", ".vtt", ".py", ".js", ".ts", ".json", ".yaml", ".yml", ".toml"]
 hidden = false
 respect_gitignore = true
 on_oversize = "skip"
@@ -21,5 +21,5 @@ image_ocr_strict = false
 
 # Stats defaults for this profile.
 [stats]
-include_ext = [".md", ".rst", ".txt", ".py", ".js", ".ts", ".json", ".yaml", ".yml", ".toml"]
+include_ext = [".md", ".rst", ".txt", ".vtt", ".py", ".js", ".ts", ".json", ".yaml", ".yml", ".toml"]
 hidden = false

--- a/tests/data/init_profiles/legal.toml
+++ b/tests/data/init_profiles/legal.toml
@@ -5,7 +5,7 @@
 
 # Pack defaults for this profile.
 [pack]
-include_ext = [".txt", ".md", ".pdf", ".docx", ".csv"]
+include_ext = [".txt", ".md", ".pdf", ".docx", ".csv", ".vtt"]
 hidden = false
 respect_gitignore = true
 on_oversize = "truncate"
@@ -21,5 +21,5 @@ image_ocr_strict = false
 
 # Stats defaults for this profile.
 [stats]
-include_ext = [".txt", ".md", ".pdf", ".docx", ".csv"]
+include_ext = [".txt", ".md", ".pdf", ".docx", ".csv", ".vtt"]
 hidden = false

--- a/tests/data/init_profiles/research.toml
+++ b/tests/data/init_profiles/research.toml
@@ -5,7 +5,7 @@
 
 # Pack defaults for this profile.
 [pack]
-include_ext = [".txt", ".md", ".rst", ".pdf", ".docx", ".xlsx", ".csv", ".tsv", ".json", ".yaml", ".yml"]
+include_ext = [".txt", ".md", ".rst", ".pdf", ".docx", ".xlsx", ".csv", ".tsv", ".vtt", ".json", ".yaml", ".yml"]
 hidden = false
 respect_gitignore = true
 on_oversize = "truncate"
@@ -21,5 +21,5 @@ image_ocr_strict = false
 
 # Stats defaults for this profile.
 [stats]
-include_ext = [".txt", ".md", ".rst", ".pdf", ".docx", ".xlsx", ".csv", ".tsv", ".json", ".yaml", ".yml"]
+include_ext = [".txt", ".md", ".rst", ".pdf", ".docx", ".xlsx", ".csv", ".tsv", ".vtt", ".json", ".yaml", ".yml"]
 hidden = false

--- a/tests/data/init_profiles/support.toml
+++ b/tests/data/init_profiles/support.toml
@@ -5,7 +5,7 @@
 
 # Pack defaults for this profile.
 [pack]
-include_ext = [".txt", ".md", ".json", ".yaml", ".yml", ".csv", ".tsv", ".log"]
+include_ext = [".txt", ".md", ".json", ".yaml", ".yml", ".csv", ".tsv", ".vtt", ".log"]
 hidden = false
 respect_gitignore = true
 on_oversize = "truncate"
@@ -21,5 +21,5 @@ image_ocr_strict = false
 
 # Stats defaults for this profile.
 [stats]
-include_ext = [".txt", ".md", ".json", ".yaml", ".yml", ".csv", ".tsv", ".log"]
+include_ext = [".txt", ".md", ".json", ".yaml", ".yml", ".csv", ".tsv", ".vtt", ".log"]
 hidden = false

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -58,6 +58,13 @@ class TestTextConverter:
         assert result.converter_name == "text"
         assert result.original_mime == "text/vtt"
 
+    def test_convert_uppercase_vtt_uses_lowercase_mime(self, tmp_path: Path) -> None:
+        f = tmp_path / "CAPTIONS.VTT"
+        f.write_text("WEBVTT\n\n00:00:01.000 --> 00:00:02.000\nhello\n", encoding="utf-8")
+        converter = TextConverter()
+        result = converter.convert(f, encoding="utf-8")
+        assert result.original_mime == "text/vtt"
+
     def test_convert_no_warnings_on_correct_encoding(self, tmp_path: Path) -> None:
         f = tmp_path / "simple.txt"
         f.write_text("simple text")

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -19,6 +19,10 @@ class TestTextConverter:
         converter = TextConverter()
         assert converter.can_convert(".md") is True
 
+    def test_can_convert_vtt(self) -> None:
+        converter = TextConverter()
+        assert converter.can_convert(".vtt") is True
+
     def test_cannot_convert_png(self) -> None:
         converter = TextConverter()
         assert converter.can_convert(".png") is False
@@ -37,6 +41,22 @@ class TestTextConverter:
         converter = TextConverter()
         result = converter.convert(f, encoding="utf-8")
         assert "你好" in result.content
+
+    def test_convert_vtt_preserves_timing_and_cue_text(self, tmp_path: Path) -> None:
+        f = tmp_path / "captions.vtt"
+        content = (
+            "WEBVTT\n\n"
+            "00:00:01.000 --> 00:00:03.000 align:start position:0%\n"
+            "Hello there.\n\n"
+            "00:00:03.500 --> 00:00:05.000\n"
+            "General Kenobi.\n"
+        )
+        f.write_text(content, encoding="utf-8")
+        converter = TextConverter()
+        result = converter.convert(f, encoding="utf-8")
+        assert result.content == content
+        assert result.converter_name == "text"
+        assert result.original_mime == "text/vtt"
 
     def test_convert_no_warnings_on_correct_encoding(self, tmp_path: Path) -> None:
         f = tmp_path / "simple.txt"

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -113,6 +113,19 @@ def test_binary_ext_excluded(sample_dir: Path) -> None:
     assert "image.png" not in relpaths
 
 
+def test_vtt_included_by_default(tmp_path: Path) -> None:
+    (tmp_path / "captions.vtt").write_text(
+        "WEBVTT\n\n00:00:01.000 --> 00:00:02.000\nhello\n",
+        encoding="utf-8",
+    )
+
+    included, skipped = scan(PackConfig(root=tmp_path))
+
+    relpaths = [r.relpath for r in included]
+    assert "captions.vtt" in relpaths
+    assert all(skip.relpath != "captions.vtt" for skip in skipped)
+
+
 def test_image_ocr_include_ext_overrides_default_image_exclude(sample_dir: Path) -> None:
     config = PackConfig(root=sample_dir, include_ext=[".png"], image_ocr=True)
     included, _ = scan(config)


### PR DESCRIPTION
## Summary
Add core WebVTT (`.vtt`) support to `foldermix` by treating VTT files as plain text.

This keeps the implementation intentionally simple:
- no new converter class
- no new dependency or optional extra
- no subtitle-aware cleanup or timestamp stripping
- no new CLI/config surface

Instead, `.vtt` is handled by the existing built-in `TextConverter` and is included by default in scans.

## Behavior
After this change:
- `.vtt` files are included by default in `scan`, `pack`, `list`, `skiplist`, and `preview`, subject to the usual filters.
- VTT content is preserved as-is, including:
  - the `WEBVTT` header
  - cue timings
  - cue settings
  - cue payload text
- output metadata stays on the core text path:
  - `converter_name="text"`
  - MIME follows the existing text converter shape and resolves to `text/vtt` for `.vtt`

## Implementation
### Core defaults
- add `.vtt` to the global default include extension list
- add `.vtt` to the text converter allowlist

### Init profiles
Add `.vtt` to the generated include lists for:
- `legal`
- `research`
- `support`
- `engineering-docs`
- `course-refresh`

This keeps init-generated `foldermix.toml` output aligned with the new default support.

### Documentation
- document VTT as a core text-like format
- update profile/docs language where included formats are enumerated
- do not describe VTT as an optional converter feature

## Testing
Added/updated tests for:
- `TextConverter.can_convert(".vtt")`
- VTT conversion preserving header/timestamps/cue text unchanged
- default scanner inclusion of `.vtt`
- init profile generated TOML fixtures and profile checks

Local verification run:
```bash
pytest -c /dev/null tests/test_converters.py tests/test_scanner.py tests/test_cli_init.py tests/test_init_profiles.py
```

## Why this approach
This PR chooses the lowest-complexity path that matches the repo’s existing architecture:
- WebVTT is a text file format
- users get support out of the box
- the change avoids special parsing behavior that could become lossy or opinionated

If subtitle-specific normalization is ever desired later, that can be a separate follow-up feature rather than being baked into the first VTT support PR.