### PR TITLE
[codex] Add PPSX support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,7 @@ Use `--print-effective-config` on any command to inspect the merged result with 
 | `test_perf_smoke.py` | `slow` | 1,500 synthetic files; asserts ≤ 25 s wall-clock (configurable via `FOLDERMIX_PERF_MAX_SECONDS`) and ≤ 256 MB `tracemalloc` peak (configurable via `FOLDERMIX_PERF_MAX_PEAK_MB`) |
 | `integration/test_pack_outputs.py` | `integration` | Golden-file snapshot tests for md/xml/jsonl output |
 | `integration/test_pack_outputs_structured.py` | `integration` | Structured assertions on TOC, SHA-256, XML structure |
-| `integration/test_converters_real_files.py` | `integration` | Real-file converter tests (PDF, docx, xlsx, pptx) |
+| `integration/test_converters_real_files.py` | `integration` | Real-file converter tests (PDF, docx, xlsx, pptx, ppsx) |
 
 ### Snapshot tests
 Fixtures live in `tests/integration/fixtures/`:
@@ -170,6 +170,11 @@ pytest -o addopts= tests/integration/test_pack_outputs.py -m integration -v
 - Update README and docs when user-visible behavior or options change.
 - New or modified Python modules should start with `from __future__ import annotations`; document any intentional exceptions (for example, specific `__init__.py` files).
 - Use `Protocol` for interfaces; type hints throughout.
+
+## PR completion gate
+- Treat feature work and PR work as incomplete until a properly labeled, non-draft GitHub PR with a detailed description is open.
+- Assign the PR to an appropriate milestone when one exists for the work.
+- Prefer GitHub MCP tools for PR creation and metadata updates; use `gh` only for actions those tools do not support cleanly, such as creating missing labels or milestones.
 
 ## PR expectations
 - Keep PR descriptions explicit: behavior change, flags and config keys, dependency impact, and test evidence.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ pip install "foldermix[all]"   # adds PDF, OCR, Office, tqdm (excludes markitdow
 pip install "foldermix[all,markitdown]"  # full optional converter stack
 pip install "foldermix[pdf]"   # pypdf only
 pip install "foldermix[ocr]"   # OCR for textless PDF pages and standalone PNG/JPEG images
-pip install "foldermix[office]" # docx/xlsx/pptx support
+pip install "foldermix[office]" # docx/xlsx/pptx/ppsx support
 ```
 
 ### Homebrew (macOS/Linux)
@@ -140,7 +140,7 @@ foldermix version
 - **Multiple output formats**: Markdown, XML, JSONL
 - **Smart filtering**: gitignore support, extension filters, glob patterns
 - **Sensitive file protection**: Automatically skips `.env`, keys, certificates
-- **Optional converters**: PDF (pypdf), OCR-enhanced PDF fallback (rapidocr + pypdfium2), Office docs (python-docx, openpyxl, python-pptx), markitdown
+- **Optional converters**: PDF (pypdf), OCR-enhanced PDF fallback (rapidocr + pypdfium2), Office docs (python-docx, openpyxl, python-pptx for `.pptx`/`.ppsx`), markitdown
 - **Core text-like formats**: plain text, markup, config/data files, and WebVTT (`.vtt`) via the built-in text converter
 - **Notebook support**: built-in `.ipynb` conversion, with `--ipynb-include-outputs` to include or omit cell outputs
 - **Spreadsheet noise reduction**: XLSX fallback skips low-signal `Copy of ...` tabs by default
@@ -224,7 +224,7 @@ foldermix init --profile course-refresh --out foldermix.toml --force
 foldermix pack ./previous-course --config foldermix.toml --format md --out course-refresh-context.md --report course-refresh-report.json
 ```
 
-The `course-refresh` profile keeps teaching-material formats broad (`pdf`, `docx`, `pptx`, `ipynb`, `xlsx`, `vtt`, text/markup, structured text) while excluding common student/admin paths such as:
+The `course-refresh` profile keeps teaching-material formats broad (`pdf`, `docx`, `pptx`, `ppsx`, `ipynb`, `xlsx`, `vtt`, text/markup, structured text) while excluding common student/admin paths such as:
 
 - grades
 - rosters
@@ -655,7 +655,7 @@ python -m mutmut results
 | `test_perf_smoke.py` | `slow` | Packs 1,500 synthetic files; asserts wall-clock ≤ 25 s and peak RSS ≤ 256 MB |
 | `integration/test_pack_outputs.py` | `integration` | Golden-file snapshot tests: Markdown, XML, JSONL output match fixture files |
 | `integration/test_pack_outputs_structured.py` | `integration` | Structured assertions on actual pack output (TOC, SHA-256, XML structure) |
-| `integration/test_converters_real_files.py` | `integration` | Real-file converter tests (PDF, docx, xlsx, pptx) |
+| `integration/test_converters_real_files.py` | `integration` | Real-file converter tests (PDF, docx, xlsx, pptx, ppsx) |
 
 Snapshot fixtures live in `tests/integration/fixtures/`:
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -104,6 +104,8 @@ class Converter(Protocol):
 
 Optional converters (`pdf`, `office`, `markitdown`) are always added to the registry, but they only become active when their optional dependencies (extras) are installed (otherwise their `can_convert()` methods return `False`, making them effective no-ops). The plain-text converter is always available as a fallback. `.ipynb` notebooks are supported by a built-in converter, with pack/preview config controlling whether cell outputs are included.
 
+`.pptx` and `.ppsx` share the PowerPoint fallback path when Office support is installed; keep slideshow support aligned across defaults, docs, and tests when changing presentation handling.
+
 ---
 
 ## Test Suite
@@ -216,6 +218,12 @@ See the [Release PR Process](../README.md#release-pr-process) section in README.
 - The `publish-pypi` job compares `HEAD` vs `HEAD^` to detect the bump.
 - Snapshot fixtures must be updated in the same PR if packer output changed.
 - The `HOMEBREW_TAP_GITHUB_TOKEN` secret must be configured for tap updates to succeed.
+
+## PR completion gate
+
+- Treat feature work and PR work as incomplete until a properly labeled, non-draft GitHub PR with a detailed description is open.
+- Assign a relevant milestone when one exists.
+- Prefer GitHub MCP tools for PR creation and metadata updates; use `gh` only for unsupported actions such as creating missing labels or milestones.
 
 ---
 

--- a/foldermix/cli.py
+++ b/foldermix/cli.py
@@ -134,6 +134,7 @@ _OPTIONAL_CONVERTER_HINTS: dict[str, str] = {
     ".docx": "Install Office support with 'pip install \"foldermix[office]\"'.",
     ".xlsx": "Install Office support with 'pip install \"foldermix[office]\"'.",
     ".pptx": "Install Office support with 'pip install \"foldermix[office]\"'.",
+    ".ppsx": "Install Office support with 'pip install \"foldermix[office]\"'.",
 }
 
 

--- a/foldermix/config.py
+++ b/foldermix/config.py
@@ -47,6 +47,7 @@ DEFAULT_INCLUDE_EXT: list[str] = [
     ".pdf",
     ".docx",
     ".pptx",
+    ".ppsx",
     ".xlsx",
     ".ipynb",
 ]

--- a/foldermix/converters/markitdown_conv.py
+++ b/foldermix/converters/markitdown_conv.py
@@ -4,6 +4,13 @@ from pathlib import Path
 
 from .base import ConversionResult
 
+_OFFICE_MIME_TYPES = {
+    ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    ".ppsx": "application/vnd.openxmlformats-officedocument.presentationml.slideshow",
+}
+
 
 class MarkitdownConverter:
     EXTENSIONS = {".pdf", ".docx", ".pptx", ".ppsx", ".xlsx"}
@@ -21,8 +28,9 @@ class MarkitdownConverter:
 
         md = MarkItDown()
         result = md.convert(str(path))
+        ext = path.suffix.lower()
         return ConversionResult(
             content=result.text_content,
             converter_name="markitdown",
-            original_mime=f"application/{path.suffix.lstrip('.')}",
+            original_mime=_OFFICE_MIME_TYPES.get(ext, f"application/{ext.lstrip('.')}"),
         )

--- a/foldermix/converters/markitdown_conv.py
+++ b/foldermix/converters/markitdown_conv.py
@@ -6,7 +6,7 @@ from .base import ConversionResult
 
 
 class MarkitdownConverter:
-    EXTENSIONS = {".pdf", ".docx", ".pptx", ".xlsx"}
+    EXTENSIONS = {".pdf", ".docx", ".pptx", ".ppsx", ".xlsx"}
 
     def can_convert(self, ext: str) -> bool:
         try:

--- a/foldermix/converters/pptx_fallback.py
+++ b/foldermix/converters/pptx_fallback.py
@@ -6,11 +6,13 @@ from .base import ConversionResult
 
 
 class PptxFallbackConverter:
+    SUPPORTED_EXTENSIONS = {".pptx", ".ppsx"}
+
     def can_convert(self, ext: str) -> bool:
         try:
             import pptx  # noqa: F401
 
-            return ext.lower() == ".pptx"
+            return ext.lower() in self.SUPPORTED_EXTENSIONS
         except ImportError:
             return False
 
@@ -28,5 +30,9 @@ class PptxFallbackConverter:
         return ConversionResult(
             content="\n\n".join(slides),
             converter_name="python-pptx",
-            original_mime="application/vnd.openxmlformats-officedocument.presentationml.presentation",
+            original_mime=(
+                "application/vnd.openxmlformats-officedocument.presentationml.slideshow"
+                if path.suffix.lower() == ".ppsx"
+                else "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+            ),
         )

--- a/foldermix/init_profiles.py
+++ b/foldermix/init_profiles.py
@@ -101,6 +101,7 @@ _COURSE_REFRESH_EXT = [
     ".pdf",
     ".docx",
     ".pptx",
+    ".ppsx",
     ".ipynb",
     ".xlsx",
     ".csv",

--- a/foldermix/packer.py
+++ b/foldermix/packer.py
@@ -49,6 +49,7 @@ _STRUCTURED_TRUNCATE_AFTER_CONVERT_EXTS = {
     ".docx",
     ".xlsx",
     ".pptx",
+    ".ppsx",
     ".ipynb",
     *IMAGE_OCR_EXTENSIONS,
 }

--- a/tests/data/init_profiles/course-refresh.toml
+++ b/tests/data/init_profiles/course-refresh.toml
@@ -5,7 +5,7 @@
 
 # Pack defaults for this profile.
 [pack]
-include_ext = [".txt", ".md", ".rst", ".pdf", ".docx", ".pptx", ".ipynb", ".xlsx", ".csv", ".tsv", ".vtt", ".json", ".yaml", ".yml"]
+include_ext = [".txt", ".md", ".rst", ".pdf", ".docx", ".pptx", ".ppsx", ".ipynb", ".xlsx", ".csv", ".tsv", ".vtt", ".json", ".yaml", ".yml"]
 hidden = false
 respect_gitignore = true
 on_oversize = "truncate"
@@ -23,5 +23,5 @@ exclude_glob = ["*[Gg]rade*", "*[Rr]oster*", "*[Rr]esponse*", "*[Ff]eedback*", "
 
 # Stats defaults for this profile.
 [stats]
-include_ext = [".txt", ".md", ".rst", ".pdf", ".docx", ".pptx", ".ipynb", ".xlsx", ".csv", ".tsv", ".vtt", ".json", ".yaml", ".yml"]
+include_ext = [".txt", ".md", ".rst", ".pdf", ".docx", ".pptx", ".ppsx", ".ipynb", ".xlsx", ".csv", ".tsv", ".vtt", ".json", ".yaml", ".yml"]
 hidden = false

--- a/tests/integration/test_converters_real_files.py
+++ b/tests/integration/test_converters_real_files.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import shutil
 from pathlib import Path
 
 import pytest
@@ -95,3 +96,18 @@ def test_real_file_converter_can_convert_when_dependency_installed(
 ) -> None:
     pytest.importorskip(required_module)
     assert converter.can_convert(ext) is True
+
+
+def test_real_file_ppsx_uses_same_converter_output(tmp_path: Path) -> None:
+    pytest.importorskip("pptx")
+    src = tmp_path / "sample.ppsx"
+    shutil.copyfile(REAL_DIR / "sample.pptx", src)
+    expected = (EXPECTED_DIR / "sample_pptx.txt").read_text(encoding="utf-8")
+
+    result = PptxFallbackConverter().convert(src)
+
+    assert result.content == expected
+    assert result.converter_name == "python-pptx"
+    assert result.original_mime == (
+        "application/vnd.openxmlformats-officedocument.presentationml.slideshow"
+    )

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -142,6 +142,44 @@ class TestMarkitdownConverter:
             assert conv.can_convert(".xlsx") is True
             assert conv.can_convert(".txt") is False
 
+    @pytest.mark.parametrize(
+        ("name", "expected_mime"),
+        [
+            (
+                "sample.docx",
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            ),
+            ("sample.xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"),
+            (
+                "sample.pptx",
+                "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+            ),
+            (
+                "sample.ppsx",
+                "application/vnd.openxmlformats-officedocument.presentationml.slideshow",
+            ),
+        ],
+    )
+    def test_convert_uses_office_mime_map(
+        self, tmp_path: Path, name: str, expected_mime: str
+    ) -> None:
+        from foldermix.converters.markitdown_conv import MarkitdownConverter
+
+        path = tmp_path / name
+        path.write_text("placeholder", encoding="utf-8")
+        mock_markitdown = MagicMock()
+        mock_markitdown.MarkItDown.return_value.convert.return_value = MagicMock(
+            text_content="converted"
+        )
+
+        converter = MarkitdownConverter()
+        with patch.dict(sys.modules, {"markitdown": mock_markitdown}):
+            result = converter.convert(path)
+
+        assert result.content == "converted"
+        assert result.converter_name == "markitdown"
+        assert result.original_mime == expected_mime
+
 
 class TestImageOcrConverter:
     def test_can_convert_supported_extensions_when_installed(self) -> None:

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -138,6 +138,7 @@ class TestMarkitdownConverter:
             assert conv.can_convert(".pdf") is True
             assert conv.can_convert(".docx") is True
             assert conv.can_convert(".pptx") is True
+            assert conv.can_convert(".ppsx") is True
             assert conv.can_convert(".xlsx") is True
             assert conv.can_convert(".txt") is False
 

--- a/tests/test_converters_fallback.py
+++ b/tests/test_converters_fallback.py
@@ -61,12 +61,14 @@ def test_normalize_whitespace_line_replaces_nbsp_and_trims_right_edge() -> None:
 def test_pptx_fallback_can_convert_when_installed(monkeypatch) -> None:
     monkeypatch.setitem(sys.modules, "pptx", SimpleNamespace(Presentation=lambda _: None))
     assert PptxFallbackConverter().can_convert(".pptx") is True
+    assert PptxFallbackConverter().can_convert(".ppsx") is True
     assert PptxFallbackConverter().can_convert(".txt") is False
 
 
 def test_pptx_fallback_can_convert_false_when_missing(monkeypatch) -> None:
     monkeypatch.setitem(sys.modules, "pptx", None)
     assert PptxFallbackConverter().can_convert(".pptx") is False
+    assert PptxFallbackConverter().can_convert(".ppsx") is False
 
 
 def test_pptx_fallback_convert(monkeypatch, tmp_path: Path) -> None:
@@ -83,6 +85,21 @@ def test_pptx_fallback_convert(monkeypatch, tmp_path: Path) -> None:
     assert "### Slide 2" in result.content
     assert "Slide Two" in result.content
     assert result.converter_name == "python-pptx"
+
+
+def test_ppsx_fallback_convert_uses_slideshow_mime(monkeypatch, tmp_path: Path) -> None:
+    path = tmp_path / "f.ppsx"
+    path.write_text("placeholder", encoding="utf-8")
+    slide = SimpleNamespace(shapes=[SimpleNamespace(text="Slide Show")])
+    fake_pptx = SimpleNamespace(Presentation=lambda _: SimpleNamespace(slides=[slide]))
+    monkeypatch.setitem(sys.modules, "pptx", fake_pptx)
+
+    result = PptxFallbackConverter().convert(path)
+
+    assert "Slide Show" in result.content
+    assert result.original_mime == (
+        "application/vnd.openxmlformats-officedocument.presentationml.slideshow"
+    )
 
 
 def test_xlsx_fallback_can_convert_when_installed(monkeypatch) -> None:

--- a/tests/test_packer_edges.py
+++ b/tests/test_packer_edges.py
@@ -4,6 +4,8 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 from foldermix import packer
 from foldermix.config import DEFAULT_INCLUDE_EXT, PackConfig
 from foldermix.converters.base import ConversionResult
@@ -26,6 +28,10 @@ class _RegistryOne:
 
 def test_default_include_ext_contains_ipynb() -> None:
     assert ".ipynb" in DEFAULT_INCLUDE_EXT
+
+
+def test_default_include_ext_contains_ppsx() -> None:
+    assert ".ppsx" in DEFAULT_INCLUDE_EXT
 
 
 def test_convert_record_without_converter(tmp_path: Path) -> None:
@@ -87,8 +93,11 @@ def test_convert_record_truncate_when_converter_deletes_tmp_file(tmp_path: Path)
     assert not (tmp_path / "big.txt.truncated.tmp").exists()
 
 
-def test_convert_record_truncate_structured_file_uses_original_path(tmp_path: Path) -> None:
-    path = tmp_path / "deck.pptx"
+@pytest.mark.parametrize("ext", [".pptx", ".ppsx"])
+def test_convert_record_truncate_structured_file_uses_original_path(
+    tmp_path: Path, ext: str
+) -> None:
+    path = tmp_path / f"deck{ext}"
     path.write_bytes(b"placeholder")
     seen_paths: list[Path] = []
 
@@ -104,17 +113,20 @@ def test_convert_record_truncate_structured_file_uses_original_path(tmp_path: Pa
         max_bytes=12,
         include_sha256=False,
     )
-    record = FileRecord(path=path, relpath="deck.pptx", ext=".pptx", size=16, mtime=0.0)
+    record = FileRecord(path=path, relpath=f"deck{ext}", ext=ext, size=16, mtime=0.0)
     item = packer._convert_record(record, _RegistryOne(_Conv()), config)
 
     assert seen_paths == [path]
     assert item.content == "slide text"
     assert item.truncated is False
-    assert not (tmp_path / "deck.pptx.truncated.tmp").exists()
+    assert not (tmp_path / f"deck{ext}.truncated.tmp").exists()
 
 
-def test_convert_record_truncate_structured_file_truncates_rendered_text(tmp_path: Path) -> None:
-    path = tmp_path / "deck.pptx"
+@pytest.mark.parametrize("ext", [".pptx", ".ppsx"])
+def test_convert_record_truncate_structured_file_truncates_rendered_text(
+    tmp_path: Path, ext: str
+) -> None:
+    path = tmp_path / f"deck{ext}"
     path.write_bytes(b"placeholder")
     seen_paths: list[Path] = []
 
@@ -130,13 +142,13 @@ def test_convert_record_truncate_structured_file_truncates_rendered_text(tmp_pat
         max_bytes=24,
         include_sha256=False,
     )
-    record = FileRecord(path=path, relpath="deck.pptx", ext=".pptx", size=128, mtime=0.0)
+    record = FileRecord(path=path, relpath=f"deck{ext}", ext=ext, size=128, mtime=0.0)
     item = packer._convert_record(record, _RegistryOne(_Conv()), config)
 
     assert seen_paths == [path]
     assert item.truncated is True
     assert "[TRUNCATED]" in item.content
-    assert not (tmp_path / "deck.pptx.truncated.tmp").exists()
+    assert not (tmp_path / f"deck{ext}.truncated.tmp").exists()
 
 
 def test_convert_record_applies_frontmatter_redaction_and_crlf(tmp_path: Path) -> None:

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -126,6 +126,16 @@ def test_vtt_included_by_default(tmp_path: Path) -> None:
     assert all(skip.relpath != "captions.vtt" for skip in skipped)
 
 
+def test_ppsx_included_by_default(tmp_path: Path) -> None:
+    (tmp_path / "deck.ppsx").write_bytes(b"presentation")
+
+    included, skipped = scan(PackConfig(root=tmp_path))
+
+    relpaths = [r.relpath for r in included]
+    assert "deck.ppsx" in relpaths
+    assert all(skip.relpath != "deck.ppsx" for skip in skipped)
+
+
 def test_image_ocr_include_ext_overrides_default_image_exclude(sample_dir: Path) -> None:
     config = PackConfig(root=sample_dir, include_ext=[".png"], image_ocr=True)
     included, _ = scan(config)


### PR DESCRIPTION
## Summary

This PR adds first-class `.ppsx` slideshow support anywhere `foldermix` currently treats `.pptx` as a supported PowerPoint input.

## What Changed

- added `.ppsx` to the default include-extension list and the `course-refresh` init profile
- added the Office-install hint for `.ppsx`
- taught both the `python-pptx` fallback converter and the optional MarkItDown converter to accept `.ppsx`
- kept structured-file truncation behavior aligned for `.ppsx`
- returned the slideshow MIME type for `.ppsx` inputs while preserving the existing presentation MIME for `.pptx`
- updated README and agent-oriented docs to mention `.ppsx` support and to make the PR completion gate explicit
- added unit and integration coverage for scanner inclusion, converter detection, conversion output, MIME selection, and structured truncation behavior

## Why

`foldermix` already supports `.pptx`, but `.ppsx` files were excluded by default and had no registered converter path even though they are the same PowerPoint OOXML family and are readable through `python-pptx`. This meant slideshow exports were skipped unless users forced them in, and even then they produced a no-converter placeholder instead of extracted slide text.

## Impact

- users can now pack `.ppsx` files without custom include-extension overrides
- Office-enabled environments get extracted slide text from `.ppsx` through the existing PowerPoint fallback path
- the built-in `course-refresh` profile now includes `.ppsx` alongside `.pptx`
- agent-facing repo docs now state more explicitly that feature and PR work is incomplete until a labeled, non-draft PR with a detailed description is open

## Validation

- `/Users/shaypalachy/clones/foldermix/.venv/bin/ruff check /Users/shaypalachy/clones/foldermix/foldermix /Users/shaypalachy/clones/foldermix/tests`
- `/Users/shaypalachy/clones/foldermix/.venv/bin/ruff format --check /Users/shaypalachy/clones/foldermix/foldermix /Users/shaypalachy/clones/foldermix/tests`
- `/Users/shaypalachy/clones/foldermix/.venv/bin/pytest -o addopts= /Users/shaypalachy/clones/foldermix/tests/test_converters.py /Users/shaypalachy/clones/foldermix/tests/test_converters_fallback.py /Users/shaypalachy/clones/foldermix/tests/test_packer_edges.py /Users/shaypalachy/clones/foldermix/tests/test_scanner.py /Users/shaypalachy/clones/foldermix/tests/test_cli_init.py /Users/shaypalachy/clones/foldermix/tests/integration/test_converters_real_files.py`

## Follow-up / Notes

- the local `.codex` instruction, memory, and skill updates requested alongside this work were applied locally and are intentionally not part of the repository diff
- no new dependency was required; this reuses the existing Office/MarkItDown converter paths
