### PR TITLE
Release 0.1.25

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "foldermix"
-version = "0.1.24"
+version = "0.1.25"
 description = "Pack a folder into a single LLM-friendly context file"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/integration/fixtures/expected/simple_project.jsonl
+++ b/tests/integration/fixtures/expected/simple_project.jsonl
@@ -1,4 +1,4 @@
-{"type": "header", "root": "__ROOT__", "generated_at": "2024-01-02T00:00:00+00:00", "version": "0.1.24", "file_count": 3, "total_bytes": 32, "args": {}}
+{"type": "header", "root": "__ROOT__", "generated_at": "2024-01-02T00:00:00+00:00", "version": "0.1.25", "file_count": 3, "total_bytes": 32, "args": {}}
 {"type": "file", "path": "alpha.md", "ext": ".md", "size_bytes": 8, "mtime": "2024-01-01T00:00:00+00:00", "sha256": null, "converter": "text", "original_mime": "text/md", "warnings": [], "warning_entries": [], "truncated": false, "content": "# Alpha\n"}
 {"type": "file", "path": "code.py", "ext": ".py", "size_bytes": 12, "mtime": "2024-01-01T00:00:00+00:00", "sha256": null, "converter": "text", "original_mime": "text/py", "warnings": [], "warning_entries": [], "truncated": false, "content": "print(\"hi\")\n"}
 {"type": "file", "path": "nested/note.txt", "ext": ".txt", "size_bytes": 12, "mtime": "2024-01-01T00:00:00+00:00", "sha256": null, "converter": "text", "original_mime": "text/txt", "warnings": [], "warning_entries": [], "truncated": false, "content": "line1\nline2\n"}

--- a/tests/integration/fixtures/expected/simple_project.md
+++ b/tests/integration/fixtures/expected/simple_project.md
@@ -2,7 +2,7 @@
 
 - **Root**: `__ROOT__`
 - **Generated**: 2024-01-02T00:00:00+00:00
-- **Version**: 0.1.24
+- **Version**: 0.1.25
 - **Files**: 3
 - **Total bytes**: 32
 

--- a/tests/integration/fixtures/expected/simple_project.xml
+++ b/tests/integration/fixtures/expected/simple_project.xml
@@ -3,7 +3,7 @@
   <header>
     <root>__ROOT__</root>
     <generated_at>2024-01-02T00:00:00+00:00</generated_at>
-    <version>0.1.24</version>
+    <version>0.1.25</version>
     <file_count>3</file_count>
     <total_bytes>32</total_bytes>
   </header>


### PR DESCRIPTION
## Summary
Bump the package version from `0.1.24` to `0.1.25` to cut the next release.

## What Changed
- Updated the project version in `pyproject.toml` from `0.1.24` to `0.1.25`
- Synced the golden integration fixtures that embed the package version in output headers:
  - `tests/integration/fixtures/expected/simple_project.md`
  - `tests/integration/fixtures/expected/simple_project.xml`
  - `tests/integration/fixtures/expected/simple_project.jsonl`

## Why The Fixture Updates Are Included
The release version is part of the generated bundle header across all output formats. Once the package version changes, the expected snapshot files must be updated in the same PR or the snapshot guard and local pre-commit hook fail.

## Verification
- `/Users/shaypalachy/clones/foldermix/.venv/bin/ruff check /Users/shaypalachy/clones/foldermix`
- `/Users/shaypalachy/clones/foldermix/.venv/bin/ruff format --check /Users/shaypalachy/clones/foldermix`
- `/Users/shaypalachy/clones/foldermix/.venv/bin/pytest -o addopts= /Users/shaypalachy/clones/foldermix/tests/test_version_module.py /Users/shaypalachy/clones/foldermix/tests/test_snapshot_guard.py /Users/shaypalachy/clones/foldermix/tests/integration/test_pack_outputs.py`

## Notes
- This PR is intentionally narrow and only prepares the next release.
- Publishing remains driven by the existing CI/release workflow after merge to `main`.
