### PR TITLE
[codex] Add PowerPoint formats to research profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ foldermix init --profile course-refresh --out ./foldermix.toml --force
 Available profiles:
 
 - `legal` - privacy-first defaults with full redaction and OCR enabled.
-- `research` - broad document coverage with OCR and email-only redaction.
+- `research` - broad document coverage, including PowerPoint decks and slideshows, with OCR and email-only redaction.
 - `support` - ticket/runbook focused filters with full redaction defaults.
 - `engineering-docs` - technical docs profile with frontmatter stripping and no redaction.
 - `course-refresh` - teaching-material bundle profile that excludes grades, rosters, responses, feedback, and other student/admin paths by default.

--- a/foldermix/init_profiles.py
+++ b/foldermix/init_profiles.py
@@ -72,6 +72,8 @@ _RESEARCH_EXT = [
     ".rst",
     ".pdf",
     ".docx",
+    ".pptx",
+    ".ppsx",
     ".xlsx",
     ".csv",
     ".tsv",

--- a/tests/data/init_profiles/research.toml
+++ b/tests/data/init_profiles/research.toml
@@ -5,7 +5,7 @@
 
 # Pack defaults for this profile.
 [pack]
-include_ext = [".txt", ".md", ".rst", ".pdf", ".docx", ".xlsx", ".csv", ".tsv", ".vtt", ".json", ".yaml", ".yml"]
+include_ext = [".txt", ".md", ".rst", ".pdf", ".docx", ".pptx", ".ppsx", ".xlsx", ".csv", ".tsv", ".vtt", ".json", ".yaml", ".yml"]
 hidden = false
 respect_gitignore = true
 on_oversize = "truncate"
@@ -21,5 +21,5 @@ image_ocr_strict = false
 
 # Stats defaults for this profile.
 [stats]
-include_ext = [".txt", ".md", ".rst", ".pdf", ".docx", ".xlsx", ".csv", ".tsv", ".vtt", ".json", ".yaml", ".yml"]
+include_ext = [".txt", ".md", ".rst", ".pdf", ".docx", ".pptx", ".ppsx", ".xlsx", ".csv", ".tsv", ".vtt", ".json", ".yaml", ".yml"]
 hidden = false

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -203,3 +203,19 @@ def test_course_refresh_profile_sets_exclusion_defaults(tmp_path: Path) -> None:
     patterns = parsed["pack"]["exclude_glob"]
     assert any(fnmatch("Grades.xlsx", pattern) for pattern in patterns)
     assert any(fnmatch("nested/course/Feedback Notes.docx", pattern) for pattern in patterns)
+
+
+def test_research_profile_includes_powerpoint_formats(tmp_path: Path) -> None:
+    output_path = tmp_path / "foldermix.toml"
+
+    result = runner.invoke(
+        app,
+        ["init", "--profile", "research", "--out", str(output_path)],
+    )
+
+    assert result.exit_code == 0, result.output
+    parsed = tomllib.loads(output_path.read_text(encoding="utf-8"))
+    assert ".pptx" in parsed["pack"]["include_ext"]
+    assert ".ppsx" in parsed["pack"]["include_ext"]
+    assert ".pptx" in parsed["stats"]["include_ext"]
+    assert ".ppsx" in parsed["stats"]["include_ext"]


### PR DESCRIPTION
## Summary

Update the `research` init profile so it includes both `.pptx` and `.ppsx` in the default extension set.

## What Changed

- added `.pptx` and `.ppsx` to the `research` profile extension list in `foldermix/init_profiles.py`
- updated the generated `tests/data/init_profiles/research.toml` fixture to match the profile source of truth
- added a focused CLI-init test that asserts both PowerPoint formats are present in the generated `pack` and `stats` sections
- updated the README profile description to make the research profile's PowerPoint coverage explicit

## Why

The recent `.ppsx` support work already broadened PowerPoint handling in the core conversion paths and in the `course-refresh` profile, but the `research` profile still excluded presentation formats entirely. That left the profile out of sync with the supported Office input surface for mixed-format research corpora.

## Impact

- `foldermix init --profile research` now generates configs that include both PowerPoint presentations and slideshow exports by default
- research-oriented corpora no longer need manual include-extension overrides for `.pptx` and `.ppsx`
- the fixture and test coverage now make that profile behavior explicit

## Validation

- `/Users/shaypalachy/clones/foldermix/.venv/bin/ruff check /Users/shaypalachy/clones/foldermix/foldermix/init_profiles.py /Users/shaypalachy/clones/foldermix/tests/test_cli_init.py`
- `/Users/shaypalachy/clones/foldermix/.venv/bin/ruff format --check /Users/shaypalachy/clones/foldermix/foldermix/init_profiles.py /Users/shaypalachy/clones/foldermix/tests/test_cli_init.py`
- `/Users/shaypalachy/clones/foldermix/.venv/bin/pytest -o addopts= /Users/shaypalachy/clones/foldermix/tests/test_cli_init.py /Users/shaypalachy/clones/foldermix/tests/test_init_profiles.py`

## Notes

- `course-refresh` already included `.pptx` and `.ppsx` on `main`, so this PR only updates the remaining research-profile gap.
