### PR TITLE
DOCS-PRES-1: Document CLI presentation roadmap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,6 +149,9 @@ pytest -o addopts= tests/integration/test_pack_outputs.py -m integration -v
 
 ## Common tasks
 
+### CLI presentation and documentation milestone
+Use [docs/presentation-roadmap.md](docs/presentation-roadmap.md) as the canonical plan for the current CLI presentation and documentation milestone.  Keep the work split into the four planned PRs: `DOCS-PRES-1` planning/docs roadmap, `DOCS-PRES-2` README presentation refresh, `DOCS-PRES-3` docs-site cookbook expansion, and `DOCS-PRES-4` CLI output/help presentation.  Do not combine CLI behavior changes with docs-only PRs unless the user explicitly changes the plan.
+
 ### Adding a new output format
 1. Create `foldermix/writers/myformat_writer.py` implementing the `Writer` protocol.
 2. Register it in `_get_writer()` in `foldermix/packer.py` and in the CLI format validation in `foldermix/cli.py`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,7 @@ pre-commit run --all-files
 ## Docs Site
 
 The docs site is built with MkDocs and published by `.github/workflows/docs-site.yml`.
+For the active CLI presentation and documentation milestone, see [docs/presentation-roadmap.md](docs/presentation-roadmap.md).
 
 ```bash
 pip install -e ".[docs]"

--- a/README.md
+++ b/README.md
@@ -586,6 +586,7 @@ See [SECURITY.md](SECURITY.md) for details on sensitive file handling.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
 For maintainer operational workflows (PR triage loop, coverage recovery, release/tap troubleshooting), see [docs/maintainer-playbook.md](docs/maintainer-playbook.md).
+For the current CLI presentation and documentation milestone, see [docs/presentation-roadmap.md](docs/presentation-roadmap.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -586,7 +586,6 @@ See [SECURITY.md](SECURITY.md) for details on sensitive file handling.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
 For maintainer operational workflows (PR triage loop, coverage recovery, release/tap troubleshooting), see [docs/maintainer-playbook.md](docs/maintainer-playbook.md).
-For the current CLI presentation and documentation milestone, see [docs/presentation-roadmap.md](docs/presentation-roadmap.md).
 
 ---
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -206,6 +206,19 @@ Triggered on every push to `main` and every pull request.
 4. Add tests in `tests/test_converters.py` (unit) and `tests/integration/test_converters_real_files.py` (real-file integration test).
 5. Add a fallback test in `tests/test_converters_fallback.py` that verifies graceful degradation when the extra is not installed.
 
+## CLI Presentation Roadmap
+
+Use [presentation-roadmap.md](presentation-roadmap.md) as the canonical plan for the current CLI presentation and documentation milestone.
+
+Keep the work split into four reviewable PRs:
+
+1. `DOCS-PRES-1`: Planning and docs roadmap.
+2. `DOCS-PRES-2`: README presentation refresh.
+3. `DOCS-PRES-3`: Docs site and cookbook expansion.
+4. `DOCS-PRES-4`: CLI output and help presentation.
+
+Do not combine CLI behavior changes with docs-only PRs unless the user explicitly changes the plan.  Any CLI-facing behavior or output change needs focused tests and updated user documentation.
+
 ---
 
 ## Release Checklist

--- a/docs/presentation-roadmap.md
+++ b/docs/presentation-roadmap.md
@@ -1,0 +1,124 @@
+# CLI Presentation And Documentation Roadmap
+
+This roadmap is the next documentation and CLI presentation milestone for `foldermix`.
+It tracks a focused sequence of four PRs that improve how the project explains itself,
+how users discover practical workflows, and how the terminal experience presents scan
+and pack decisions.
+
+## Milestone Goal
+
+Make `foldermix` easier to evaluate, install, and trust as an LLM-context packing CLI.
+The work should learn from prominent CLI projects without copying their voice or
+turning `foldermix` into a broader tool than it is.
+
+Reference projects to study:
+
+- `repomix` and `files-to-prompt` for AI-context positioning and direct comparisons.
+- `uv` and `ruff` for crisp installation, quickstart, feature framing, and docs hierarchy.
+- `llm` for plugin-like workflows, shell composition, and examples-first docs.
+- `ripgrep`, `fd`, and `bat` for practical command examples, readable filtering docs,
+  and visual terminal presentation.
+- `gh` and `jq` for command reference structure, workflow recipes, and machine-readable
+  output examples.
+
+## Planned PR Split
+
+### PR 1: DOCS-PRES-1: Planning And Docs Roadmap
+
+Purpose:
+- Record the milestone as an explicit roadmap item.
+- Capture the four-PR split so the work stays reviewable.
+- Link the roadmap from contributor, agent, README, and docs-site entry points.
+
+Scope:
+- Planning docs only.
+- No user-facing CLI behavior changes.
+- No README rewrite beyond short references to this roadmap.
+
+Validation:
+- Markdown/docs build check when docs dependencies are available.
+- No Python test run required unless touched files expand beyond docs.
+
+### PR 2: DOCS-PRES-2: README Presentation Refresh
+
+Purpose:
+- Make the repository front page explain the tool faster and more concretely.
+- Improve the first-screen path from install to useful output.
+- Clarify who `foldermix` is for and when to use `md`, `xml`, or `jsonl`.
+
+Scope:
+- Tighten the README title, tagline, quickstart, install matrix, and feature framing.
+- Add compact examples that show input folder, command, and resulting artifact.
+- Keep existing operational and maintainer details, but move or compress material if the
+  README becomes too long for first-time evaluation.
+
+Borrowed patterns:
+- `uv` and `ruff`: concise top section and installation clarity.
+- `repomix` and `files-to-prompt`: AI-context language and direct, concrete examples.
+- `bat`: visual or transcript-style demonstration near the top when practical.
+
+Validation:
+- Link/anchor sanity check.
+- Docs build if README content is imported by the docs site.
+
+### PR 3: DOCS-PRES-3: Docs Site And Cookbook Expansion
+
+Purpose:
+- Turn the docs site from a one-page reference into a practical workflow guide while
+  keeping it compact.
+- Give users copy-pasteable recipes for common `foldermix` jobs.
+
+Scope:
+- Add docs-site pages or sections for:
+  - AI context packing.
+  - Legal review bundles.
+  - Research corpus bundles.
+  - Support incident bundles.
+  - Course refresh bundles.
+  - Config-first workflows.
+  - Machine-readable reports and `jsonl` output.
+- Keep the README and docs site complementary: README for evaluation, docs site for use.
+- Update `mkdocs.yml` navigation as pages are added.
+
+Borrowed patterns:
+- `llm`: recipe-driven workflows.
+- `jq` and `gh`: command reference and machine-readable output examples.
+- `ripgrep` and `fd`: filtering explanations with clear examples.
+
+Validation:
+- `mkdocs build --strict`.
+- Link/anchor sanity check.
+
+### PR 4: DOCS-PRES-4: CLI Output And Help Presentation
+
+Purpose:
+- Improve the terminal experience for discovery, preview, and trust-building commands.
+- Make include/skip decisions easier to inspect before users generate context bundles.
+
+Scope:
+- Review and refine command help text, option grouping, and examples.
+- Improve readable output for `list`, `skiplist`, `stats`, and dry-run style flows where
+  useful.
+- Preserve existing machine-readable contracts and backward compatibility.
+- Add or update focused tests for any behavioral or output changes.
+
+Borrowed patterns:
+- `rich` and `bat`: terminal readability and concise presentation.
+- `gh`: command help and workflow-oriented examples.
+- `ruff`: clear diagnostics and deterministic output.
+
+Validation:
+- `ruff check .`
+- `ruff format --check .`
+- `pytest -m "not integration and not slow" -o addopts=`
+- Add integration or snapshot updates only if intentional output changes require them.
+
+## Coordination Rules
+
+- Keep each PR independently reviewable and mergeable.
+- Do not bundle CLI output changes into docs-only PRs.
+- Update README and docs when any CLI-facing behavior or terminology changes.
+- Preserve sensitive-file protections and deterministic output ordering throughout the
+  milestone.
+- Treat each PR as incomplete until it satisfies the repository PR completion gate:
+  labeled, non-draft, detailed description, and milestone assignment when available.

--- a/docs/presentation-roadmap.md
+++ b/docs/presentation-roadmap.md
@@ -1,117 +1,188 @@
 # CLI Presentation And Documentation Roadmap
 
-This roadmap is the next documentation and CLI presentation milestone for `foldermix`.
-It tracks a focused sequence of four PRs that improve how the project explains itself,
-how users discover practical workflows, and how the terminal experience presents scan
-and pack decisions.
+This roadmap tracks the `M3 CLI Presentation & Docs` milestone for `foldermix`.
+The milestone is split into four PRs so planning, README work, docs-site expansion,
+and CLI behavior changes can be reviewed independently.
 
 ## Milestone Goal
 
 Make `foldermix` easier to evaluate, install, and trust as an LLM-context packing CLI.
-The work should learn from prominent CLI projects without copying their voice or
-turning `foldermix` into a broader tool than it is.
+The work should improve the path from "what is this?" to "I can safely generate the
+context bundle I need" without expanding `foldermix` beyond folder packing.
 
-Reference projects to study:
+## Positioning Principles
 
-- `repomix` and `files-to-prompt` for AI-context positioning and direct comparisons.
-- `uv` and `ruff` for crisp installation, quickstart, feature framing, and docs hierarchy.
-- `llm` for plugin-like workflows, shell composition, and examples-first docs.
-- `ripgrep`, `fd`, and `bat` for practical command examples, readable filtering docs,
-  and visual terminal presentation.
-- `gh` and `jq` for command reference structure, workflow recipes, and machine-readable
-  output examples.
+- Lead with the concrete job: pack a folder into one LLM-friendly artifact.
+- Prefer runnable examples over feature claims.
+- Separate evaluation docs from operating docs.
+- Keep safety and determinism visible: sensitive-file skipping, preview commands,
+  reports, and stable ordering are product strengths.
+- Preserve existing output contracts unless a later PR explicitly proposes and tests a
+  behavior change.
+
+## Reference Evaluation Matrix
+
+Use these projects as a checklist for specific patterns, not as generic inspiration.
+Each follow-up PR should name which rows it used and what it deliberately avoided.
+
+| Project | Inspect | Borrow For `foldermix` | Avoid |
+|---|---|---|---|
+| `repomix` | AI-context positioning, install-to-first-output flow, comparison language | A concise explanation of why context packing exists and where `foldermix` differs | Over-claiming parity with repo-specialized tools |
+| `files-to-prompt` | Minimal examples, shell-friendly usage | A low-friction baseline example for users who want one command | A README that is too sparse for safety-sensitive document workflows |
+| `uv` | First-screen structure, install clarity, docs hierarchy | Short install paths and a clear "recommended path" for extras | Turning install docs into a general Python packaging tutorial |
+| `ruff` | Feature framing, diagnostics style, migration/confidence messaging | Clear promises around speed, determinism, and predictable behavior | Broad benchmark claims unless locally measured |
+| `llm` | Recipes, shell composition, plugin-like workflow docs | Cookbook pages that show end-to-end LLM workflow usage | Making optional converters sound required for core use |
+| `ripgrep` | Filtering examples and comparison framing | Concrete include/exclude examples and precise defaults | Dense option dumps before the user understands the workflow |
+| `fd` | Friendly discovery docs and examples | Human-readable file-selection explanations | Hiding edge cases such as hidden files and gitignore behavior |
+| `bat` | Terminal screenshots/transcripts and visual proof | Compact output transcripts or screenshots where they clarify behavior | Decorative visuals that do not show real `foldermix` output |
+| `gh` | Command reference organization and workflow language | Task-oriented command docs and help examples | GitHub-specific assumptions in general CLI docs |
+| `jq` | Machine-readable examples and pipelines | `jsonl` and `--report` examples users can pipe into other tools | Advanced query examples that distract from core packing workflows |
 
 ## Planned PR Split
 
-### PR 1: DOCS-PRES-1: Planning And Docs Roadmap
+### DOCS-PRES-1: Planning And Docs Roadmap
 
 Purpose:
 - Record the milestone as an explicit roadmap item.
 - Capture the four-PR split so the work stays reviewable.
-- Link the roadmap from contributor, agent, README, and docs-site entry points.
+- Link the roadmap from contributor, agent, and docs-site entry points.
 
-Scope:
-- Planning docs only.
+Deliverables:
+- Canonical roadmap in `docs/presentation-roadmap.md`.
+- Docs-site roadmap page with enough content to stand on its own.
+- Links from `CONTRIBUTING.md`, `AGENTS.md`, `docs/agents.md`, and the docs site.
+- GitHub milestone and PR metadata using `M3 CLI Presentation & Docs`.
+
+Non-goals:
 - No user-facing CLI behavior changes.
-- No README rewrite beyond short references to this roadmap.
+- No README presentation rewrite.
+- No new screenshots, benchmarks, or command-output changes.
+
+Acceptance criteria:
+- The roadmap names all four PRs with stable `DOCS-PRES-*` notation.
+- Each follow-up PR has deliverables, non-goals, validation, and acceptance criteria.
+- The docs-site page does not send users to a main-branch repository blob as its primary
+  content.
+- Public user-facing docs avoid time-sensitive "current milestone" language.
 
 Validation:
-- Markdown/docs build check when docs dependencies are available.
-- No Python test run required unless touched files expand beyond docs.
+- `uv run --extra docs mkdocs build --strict`.
+- `git diff --check`.
+- Commit hook `pytest-fast`.
 
-### PR 2: DOCS-PRES-2: README Presentation Refresh
+### DOCS-PRES-2: README Presentation Refresh
 
 Purpose:
 - Make the repository front page explain the tool faster and more concretely.
 - Improve the first-screen path from install to useful output.
 - Clarify who `foldermix` is for and when to use `md`, `xml`, or `jsonl`.
 
-Scope:
-- Tighten the README title, tagline, quickstart, install matrix, and feature framing.
-- Add compact examples that show input folder, command, and resulting artifact.
-- Keep existing operational and maintainer details, but move or compress material if the
-  README becomes too long for first-time evaluation.
+Deliverables:
+- Revised README opening with:
+  - one plain-language product sentence;
+  - one copy-paste quickstart command;
+  - a short "what you get" output example or transcript;
+  - a concise list of the main safety guarantees.
+- Install section with a clearly recommended default path and an extras decision table.
+- Format guidance explaining when to choose Markdown, XML, and JSONL.
+- A compact "common workflows" block that points to the deeper docs-site cookbook.
+- Preserved maintainer/developer sections, moved lower or compressed when needed.
 
-Borrowed patterns:
-- `uv` and `ruff`: concise top section and installation clarity.
-- `repomix` and `files-to-prompt`: AI-context language and direct, concrete examples.
-- `bat`: visual or transcript-style demonstration near the top when practical.
+Non-goals:
+- No CLI output or option behavior changes.
+- No docs-site restructuring beyond links needed to keep navigation coherent.
+- No performance or adoption claims without evidence in the PR.
+
+Acceptance criteria:
+- A new user can identify the tool's purpose and run a useful command within the first
+  visible README section.
+- Optional extras are explained without implying Homebrew supports them.
+- Existing release, security, and maintainer information remains discoverable.
+- The README does not duplicate long command-reference material that belongs in the docs
+  site.
 
 Validation:
-- Link/anchor sanity check.
-- Docs build if README content is imported by the docs site.
+- Link and anchor sanity check for changed README sections.
+- `uv run --extra docs mkdocs build --strict` if docs-site links are changed.
 
-### PR 3: DOCS-PRES-3: Docs Site And Cookbook Expansion
+### DOCS-PRES-3: Docs Site And Cookbook Expansion
 
 Purpose:
 - Turn the docs site from a one-page reference into a practical workflow guide while
   keeping it compact.
 - Give users copy-pasteable recipes for common `foldermix` jobs.
 
-Scope:
-- Add docs-site pages or sections for:
-  - AI context packing.
-  - Legal review bundles.
-  - Research corpus bundles.
-  - Support incident bundles.
-  - Course refresh bundles.
-  - Config-first workflows.
-  - Machine-readable reports and `jsonl` output.
-- Keep the README and docs site complementary: README for evaluation, docs site for use.
-- Update `mkdocs.yml` navigation as pages are added.
+Deliverables:
+- MkDocs navigation for at least:
+  - Quickstart;
+  - Workflows;
+  - Configuration;
+  - Output formats and reports;
+  - Safety and troubleshooting.
+- Cookbook recipes for:
+  - AI context packing;
+  - legal review bundles;
+  - research corpus bundles;
+  - support incident bundles;
+  - course refresh bundles;
+  - config-first workflows;
+  - machine-readable reports and `jsonl` pipelines.
+- Each recipe must include:
+  - when to use it;
+  - command sequence;
+  - expected artifact;
+  - relevant safety or filtering note.
+- README links to the docs-site pages instead of duplicating recipe details.
 
-Borrowed patterns:
-- `llm`: recipe-driven workflows.
-- `jq` and `gh`: command reference and machine-readable output examples.
-- `ripgrep` and `fd`: filtering explanations with clear examples.
+Non-goals:
+- No CLI output or option behavior changes.
+- No broad redesign or custom theme work.
+- No claims that optional converters are installed by default.
+
+Acceptance criteria:
+- `mkdocs build --strict` passes.
+- Every new page is reachable from `mkdocs.yml` navigation.
+- The docs site is useful without reading the full README first.
+- Workflow pages use real `foldermix` commands and current option names.
 
 Validation:
-- `mkdocs build --strict`.
-- Link/anchor sanity check.
+- `uv run --extra docs mkdocs build --strict`.
+- Link and anchor sanity check.
 
-### PR 4: DOCS-PRES-4: CLI Output And Help Presentation
+### DOCS-PRES-4: CLI Output And Help Presentation
 
 Purpose:
 - Improve the terminal experience for discovery, preview, and trust-building commands.
 - Make include/skip decisions easier to inspect before users generate context bundles.
 
-Scope:
-- Review and refine command help text, option grouping, and examples.
+Deliverables:
+- Review and refine command help text for `pack`, `list`, `skiplist`, `preview`,
+  `stats`, `init`, and `version`.
+- Add help examples or command epilogues only where Typer/Rich can present them cleanly.
 - Improve readable output for `list`, `skiplist`, `stats`, and dry-run style flows where
-  useful.
-- Preserve existing machine-readable contracts and backward compatibility.
-- Add or update focused tests for any behavioral or output changes.
+  the current output makes include/skip decisions hard to inspect.
+- Preserve machine-readable output and report schemas unless an intentional schema change
+  is separately documented.
+- Update README/docs-site examples affected by any output or terminology change.
 
-Borrowed patterns:
-- `rich` and `bat`: terminal readability and concise presentation.
-- `gh`: command help and workflow-oriented examples.
-- `ruff`: clear diagnostics and deterministic output.
+Non-goals:
+- No new output format.
+- No new converter stack.
+- No dependency addition unless the PR explicitly justifies it and proves it is needed;
+  prefer the existing Typer/Rich stack.
+- No breaking change to report JSON, JSONL bundle output, or scanner ordering.
+
+Acceptance criteria:
+- Help text remains accurate for every changed option.
+- Human-readable output is easier to scan while staying deterministic.
+- Tests cover changed help/output behavior.
+- Any snapshot or integration fixture changes are intentional and explained in the PR.
 
 Validation:
-- `ruff check .`
-- `ruff format --check .`
-- `pytest -m "not integration and not slow" -o addopts=`
-- Add integration or snapshot updates only if intentional output changes require them.
+- `ruff check .`.
+- `ruff format --check .`.
+- `pytest -m "not integration and not slow" -o addopts=`.
+- Integration/snapshot tests only when changed output requires them.
 
 ## Coordination Rules
 
@@ -120,5 +191,7 @@ Validation:
 - Update README and docs when any CLI-facing behavior or terminology changes.
 - Preserve sensitive-file protections and deterministic output ordering throughout the
   milestone.
+- Use the `DOCS-PRES-*` notation in PR titles and the PR body's planning notation
+  section.
 - Treat each PR as incomplete until it satisfies the repository PR completion gate:
   labeled, non-draft, detailed description, and milestone assignment when available.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ theme:
 docs_dir: site-docs
 nav:
   - Home: index.md
+  - CLI Presentation Roadmap: cli-presentation-roadmap.md
 markdown_extensions:
   - admonition
   - tables

--- a/site-docs/cli-presentation-roadmap.md
+++ b/site-docs/cli-presentation-roadmap.md
@@ -1,14 +1,89 @@
 # CLI Presentation Roadmap
 
-The canonical planning document for this milestone is
-[docs/presentation-roadmap.md](https://github.com/foldermix/foldermix/blob/main/docs/presentation-roadmap.md).
+This page summarizes the `M3 CLI Presentation & Docs` milestone. The detailed source
+of truth lives in the repository at `docs/presentation-roadmap.md`; this published page
+keeps the reviewable PR split visible from the docs site without requiring readers to
+jump to GitHub for the basic plan.
 
-The milestone is split into four PRs:
+## Goal
 
-1. `DOCS-PRES-1`: Planning and docs roadmap.
-2. `DOCS-PRES-2`: README presentation refresh.
-3. `DOCS-PRES-3`: Docs site and cookbook expansion.
-4. `DOCS-PRES-4`: CLI output and help presentation.
+Make `foldermix` easier to evaluate, install, and trust as an LLM-context packing CLI.
+The milestone improves presentation and documentation without expanding `foldermix`
+beyond folder packing.
 
-Keep docs-only PRs separate from CLI behavior changes unless the plan is explicitly
-changed.
+## Principles
+
+- Lead with the concrete job: pack a folder into one LLM-friendly artifact.
+- Prefer runnable examples over feature claims.
+- Separate evaluation docs from operating docs.
+- Keep safety and determinism visible: sensitive-file skipping, preview commands,
+  reports, and stable ordering.
+- Preserve output contracts unless a later PR explicitly proposes and tests a behavior
+  change.
+
+## Reference Projects
+
+The milestone uses prominent CLI tools as pattern references:
+
+| Project | Borrow | Avoid |
+|---|---|---|
+| `repomix` | AI-context positioning and first-output flow | Over-claiming parity with repo-specialized tools |
+| `files-to-prompt` | Minimal shell-friendly examples | Docs that are too sparse for safety-sensitive workflows |
+| `uv` | Install clarity and first-screen structure | A general Python packaging tutorial |
+| `ruff` | Clear promises around speed and deterministic behavior | Benchmark claims without local evidence |
+| `llm` | Recipe-driven workflows | Making optional converters sound required |
+| `ripgrep` and `fd` | Precise filtering examples | Dense option dumps before workflow context |
+| `bat` | Useful terminal transcripts or screenshots | Decorative visuals that do not show real output |
+| `gh` and `jq` | Command-reference structure and machine-readable examples | Domain-specific assumptions that do not fit `foldermix` |
+
+## PR Split
+
+### DOCS-PRES-1: Planning And Docs Roadmap
+
+Records this roadmap, links it from contributor and agent docs, and keeps the docs-site
+version useful on its own. It does not change CLI behavior or rewrite the README.
+
+Acceptance criteria:
+- Stable `DOCS-PRES-*` notation exists.
+- Follow-up PRs have deliverables, non-goals, validation, and acceptance criteria.
+- Public docs avoid time-sensitive "current milestone" language.
+
+### DOCS-PRES-2: README Presentation Refresh
+
+Refreshes the README opening, install guidance, format guidance, and short workflow
+entry points.
+
+Acceptance criteria:
+- A new user can identify the purpose and run a useful command from the first visible
+  README section.
+- Optional extras are clear without implying Homebrew supports them.
+- Maintainer, security, and release details remain discoverable.
+
+### DOCS-PRES-3: Docs Site And Cookbook Expansion
+
+Expands the docs site into a compact workflow guide with cookbook recipes for AI context
+packing, legal review, research corpora, support incidents, course refreshes,
+config-first workflows, and machine-readable reports.
+
+Acceptance criteria:
+- `mkdocs build --strict` passes.
+- Every new page is reachable from navigation.
+- Recipes use real `foldermix` commands and current option names.
+
+### DOCS-PRES-4: CLI Output And Help Presentation
+
+Improves command help and human-readable output for discovery, preview, and trust-building
+commands while preserving machine-readable contracts.
+
+Acceptance criteria:
+- Help text remains accurate for changed options.
+- Output changes are deterministic and covered by tests.
+- Report JSON, JSONL bundle output, and scanner ordering stay backward compatible unless
+  explicitly changed and documented.
+
+## Coordination Rules
+
+- Keep each PR independently reviewable and mergeable.
+- Keep docs-only PRs separate from CLI behavior changes.
+- Update README and docs when CLI-facing terminology or behavior changes.
+- Preserve sensitive-file protections and deterministic output ordering.

--- a/site-docs/cli-presentation-roadmap.md
+++ b/site-docs/cli-presentation-roadmap.md
@@ -1,0 +1,14 @@
+# CLI Presentation Roadmap
+
+The canonical planning document for this milestone is
+[docs/presentation-roadmap.md](https://github.com/foldermix/foldermix/blob/main/docs/presentation-roadmap.md).
+
+The milestone is split into four PRs:
+
+1. `DOCS-PRES-1`: Planning and docs roadmap.
+2. `DOCS-PRES-2`: README presentation refresh.
+3. `DOCS-PRES-3`: Docs site and cookbook expansion.
+4. `DOCS-PRES-4`: CLI output and help presentation.
+
+Keep docs-only PRs separate from CLI behavior changes unless the plan is explicitly
+changed.

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -165,6 +165,7 @@ Publish path:
 
 This site is intentionally concise. For deeper details, use:
 - [README](https://github.com/foldermix/foldermix/blob/main/README.md)
+- [CLI presentation roadmap](cli-presentation-roadmap.md)
 - [Config-first workflows](https://github.com/foldermix/foldermix/blob/main/docs/config-first-workflows.md)
 - [Compliance and safety](https://github.com/foldermix/foldermix/blob/main/docs/compliance-safety.md)
 - [Contributing](https://github.com/foldermix/foldermix/blob/main/CONTRIBUTING.md)


### PR DESCRIPTION
## Planning notation

- Notation: `DOCS-PRES-1`
- Parent milestone: `M3 CLI Presentation & Docs`
- Plan source: `docs/presentation-roadmap.md`

## Summary

This PR records the next CLI presentation and documentation milestone as a concrete planning artifact and splits the work into four reviewable PRs:

1. `DOCS-PRES-1`: Planning and docs roadmap.
2. `DOCS-PRES-2`: README presentation refresh.
3. `DOCS-PRES-3`: Docs site and cookbook expansion.
4. `DOCS-PRES-4`: CLI output and help presentation.

## What changed

- Added `docs/presentation-roadmap.md` as the canonical roadmap for the milestone.
- Added a docs-site roadmap page and MkDocs navigation entry.
- Linked the roadmap from the contributing guide, docs-site index, and agent guides.
- Updated agent instructions to preserve the planned PR split and keep docs-only work separate from CLI behavior changes.
- Tightened the roadmap after self-review with explicit deliverables, non-goals, acceptance criteria, and validation for each planned PR.
- Added a reference-project evaluation matrix that states what `foldermix` should borrow and avoid.
- Removed time-sensitive roadmap wording from the user-facing README.

## Self-review recommendations applied

- Made follow-up PR scope enforceable by replacing broad verbs with concrete deliverables and acceptance criteria.
- Converted the reference-project list into a decision matrix so future work cannot cite inspiration vaguely.
- Reworked the docs-site roadmap page so it stands on its own instead of sending readers to a main-branch GitHub blob for the basic plan.
- Kept transient milestone wording out of the README and limited roadmap links to contributor, agent, and docs-site surfaces.

## Impact

- Documentation and planning only.
- No CLI behavior changes.
- No package dependency changes.

## Validation

- `uv run --extra docs mkdocs build --strict`
- `git diff --check`
- Commit hook `pytest-fast` passed during both commits.
