### PR TITLE
DOCS-PRES-3: Expand docs site and cookbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ foldermix pack . --format jsonl --out context.jsonl --report report.json
 
 ## Common Workflows
 
-Use these as compact starting points. The longer docs-site guides cover [workflows](https://foldermix.github.io/foldermix/workflows/), [configuration](https://foldermix.github.io/foldermix/configuration/), [output formats and reports](https://foldermix.github.io/foldermix/output-formats-and-reports/), and [safety and troubleshooting](https://foldermix.github.io/foldermix/safety-and-troubleshooting/).
+Use these as compact starting points. The longer docs-site guides cover [workflows](site-docs/workflows.md), [configuration](site-docs/configuration.md), [output formats and reports](site-docs/output-formats-and-reports.md), and [safety and troubleshooting](site-docs/safety-and-troubleshooting.md).
 
 Config-first project bundle:
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ foldermix pack . --format jsonl --out context.jsonl --report report.json
 
 ## Common Workflows
 
-Use these as compact starting points. The longer walkthroughs live in [Config-first workflows](docs/config-first-workflows.md), [Compliance and safety](docs/compliance-safety.md), and the [docs-site workflow examples](https://foldermix.github.io/foldermix/#common-workflows).
+Use these as compact starting points. The longer docs-site guides cover [workflows](https://foldermix.github.io/foldermix/workflows/), [configuration](https://foldermix.github.io/foldermix/configuration/), [output formats and reports](https://foldermix.github.io/foldermix/output-formats-and-reports/), and [safety and troubleshooting](https://foldermix.github.io/foldermix/safety-and-troubleshooting/).
 
 Config-first project bundle:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,11 @@ theme:
 docs_dir: site-docs
 nav:
   - Home: index.md
+  - Quickstart: quickstart.md
+  - Workflows: workflows.md
+  - Configuration: configuration.md
+  - Output Formats And Reports: output-formats-and-reports.md
+  - Safety And Troubleshooting: safety-and-troubleshooting.md
   - CLI Presentation Roadmap: cli-presentation-roadmap.md
 markdown_extensions:
   - admonition

--- a/site-docs/configuration.md
+++ b/site-docs/configuration.md
@@ -1,0 +1,68 @@
+# Configuration
+
+`foldermix` can run with no config file, but repeatable workflows should use `foldermix.toml`.
+
+## Resolution Order
+
+Effective options are resolved in this deterministic order:
+
+1. Built-in defaults
+2. `foldermix.toml`
+3. Explicit CLI flags
+
+Higher layers override lower layers.
+
+## Config Discovery
+
+Use an explicit config path when you want the run to be unambiguous:
+
+```bash
+foldermix pack . --config foldermix.toml --out context.md
+```
+
+When `--config` is omitted, `foldermix` discovers `foldermix.toml` by walking upward from the target path.
+
+## Sections
+
+- `[pack]` controls file-selection and packing behavior shared by `pack`, `list`, and `skiplist`.
+- `[stats]` keeps stats-specific defaults separate.
+- `[common]` can hold shared settings supported by the config loader.
+
+Use this command to inspect the merged result and value sources:
+
+```bash
+foldermix pack . --config foldermix.toml --print-effective-config
+foldermix list . --config foldermix.toml --print-effective-config
+foldermix stats . --config foldermix.toml --print-effective-config
+```
+
+## Starter Profiles
+
+Generate a commented starter config with `foldermix init`:
+
+```bash
+foldermix init --profile legal --out foldermix.toml --force
+foldermix init --profile research --out foldermix.toml --force
+foldermix init --profile support --out foldermix.toml --force
+foldermix init --profile engineering-docs --out foldermix.toml --force
+foldermix init --profile course-refresh --out foldermix.toml --force
+```
+
+Profile intent:
+
+- `legal`: privacy-first defaults, full redaction, PDF OCR fallback enabled.
+- `research`: broad mixed-document coverage, email redaction, OCR enabled.
+- `support`: ticket and runbook focused filters with full redaction.
+- `engineering-docs`: docs/code handoff defaults, frontmatter stripping, no redaction.
+- `course-refresh`: teaching-material defaults with exclusions for student/admin paths.
+
+## Stdin File Lists
+
+Use stdin when the input list should come from another command:
+
+```bash
+printf 'a.txt\nnested/b.txt\n' | foldermix pack . --config foldermix.toml --stdin --format jsonl --out context.jsonl
+find . -type f -print0 | foldermix pack . --config foldermix.toml --stdin --null --format md --out context.md
+```
+
+`--null` requires `--stdin` and is intended for NUL-delimited input such as `find -print0`.

--- a/site-docs/configuration.md
+++ b/site-docs/configuration.md
@@ -26,7 +26,7 @@ When `--config` is omitted, `foldermix` discovers `foldermix.toml` by walking up
 
 - `[pack]` controls file-selection and packing behavior shared by `pack`, `list`, and `skiplist`.
 - `[stats]` keeps stats-specific defaults separate.
-- `[common]` can hold shared settings supported by the config loader.
+- `[common]` is copied into command sections, so use it only for keys that are valid for every command that will read that config.
 
 Use this command to inspect the merged result and value sources:
 

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -1,171 +1,41 @@
 # foldermix Docs
 
-`foldermix` packs a directory into a single LLM-friendly context file. The v1 docs site is intentionally one page: enough to install the tool, run it immediately, and find the core commands without reading the full README end to end.
+`foldermix` packs a local folder into one LLM-friendly context artifact you can inspect, share, or pipe into automation.
 
-## What It Does
+## Where To Go Next
 
-Use `foldermix` when you want to turn a folder of text and document files into one context artifact for an LLM workflow.
+- [Quickstart](quickstart.md): install `foldermix`, run the first pack, and preview what will be included.
+- [Workflows](workflows.md): copy-pasteable recipes for AI context, legal review, research, support, course refresh, config-first, and `jsonl` report pipelines.
+- [Configuration](configuration.md): config precedence, `foldermix.toml` discovery, command sections, starter profiles, and effective-config diagnostics.
+- [Output Formats And Reports](output-formats-and-reports.md): when to choose Markdown, XML, or JSONL, and how to use `--report`.
+- [Safety And Troubleshooting](safety-and-troubleshooting.md): sensitive-file handling, filters, policy dry-runs, OCR notes, and common fixes.
+- [CLI Presentation Roadmap](cli-presentation-roadmap.md): the M3 documentation and CLI presentation plan.
 
-Core capabilities:
-- pack a folder into `md`, `xml`, or `jsonl`
-- preview what will be included or skipped before packing
-- handle optional PDF and Office converters when installed
-- emit a machine-readable report for audits and cleanup workflows
+## First Command
 
-## Install
+```bash
+foldermix pack . --out context.md
+```
 
-### Core install
+This writes a Markdown bundle for the current folder. Run `foldermix list .` and `foldermix skiplist .` first when you want to inspect include and skip decisions before producing a bundle.
+
+## Install Paths
 
 ```bash
 pip install foldermix
 ```
 
-### Homebrew
+The default install is enough for text, Markdown, source code, config/data files, WebVTT, and notebooks.
+
+Homebrew is available for the core CLI:
 
 ```bash
 brew tap foldermix/foldermix
 brew install foldermix
 ```
 
-Homebrew installs the core feature set only.
-
-### Full optional converter support
+Homebrew does not install optional Python extras. Use a Python tool install when you need PDF, OCR, Office, or `markitdown` support:
 
 ```bash
-# uv (recommended)
 uv tool install "foldermix[all,markitdown]"
-
-# pipx
-pipx install "foldermix[all,markitdown]"
 ```
-
-Optional extras:
-- `pdf`: native PDF text extraction
-- `ocr`: OCR fallback for textless PDFs
-- `office`: `docx` / `xlsx` / `pptx`
-- `markitdown`: additional converter support
-
-## Super Quick Start
-
-Run this from the folder you want to pack:
-
-```bash
-foldermix pack . --out context.md
-```
-
-This writes one Markdown bundle to `./context.md`.
-
-Defaults worth knowing:
-- default output format is Markdown (`md`)
-- if you omit `--out`, `foldermix` writes a timestamped Markdown file such as `foldermix_20260307_120000.md`
-
-## Core Commands
-
-### `pack`
-
-```bash
-foldermix pack PATH [--out FILE] [--format md|xml|jsonl]
-```
-
-Use `pack` to create the final bundle.
-
-Common flags:
-- `--report report.json`: write a machine-readable report
-- `--dedupe-content`: skip later exact-duplicate files by content hash
-- `--include-ext`, `--exclude-ext`, `--exclude-dirs`, `--exclude-glob`
-- `--pdf-ocr`: enable OCR fallback when OCR dependencies are installed
-
-### `list`
-
-```bash
-foldermix list PATH
-```
-
-Shows which files would be included by the current pack-style filtering rules.
-
-### `skiplist`
-
-```bash
-foldermix skiplist PATH
-```
-
-Shows which files would be skipped and why.
-
-### `stats`
-
-```bash
-foldermix stats PATH
-```
-
-Shows extension and byte-size statistics for the selected tree.
-
-### `version`
-
-```bash
-foldermix version
-```
-
-Prints the installed version.
-
-## Common Workflows
-
-### Config-first project workflow
-
-```bash
-foldermix init --profile engineering-docs
-foldermix pack . --config foldermix.toml --format md --out context.md --report report.json
-```
-
-### Research corpus batch run
-
-```bash
-find ./corpus -type f -print0 | foldermix pack ./corpus --config foldermix.toml --stdin --null --format jsonl --out research-context.jsonl --report research-report.json
-```
-
-### Course refresh bundle
-
-```bash
-foldermix init --profile course-refresh --out foldermix.toml --force
-foldermix pack ./previous-course --config foldermix.toml --format md --out course-refresh-context.md --report course-refresh-report.json
-```
-
-### Duplicate cleanup before LLM ingestion
-
-```bash
-foldermix pack ./corpus --format md --out deduped-context.md --report dedupe-report.json --dedupe-content
-```
-
-## Optional Dependency Guidance
-
-Choose the install method based on the workflow:
-- Homebrew: fastest system install, core features only
-- `uv tool`: best isolated global install with extras
-- `pipx`: similar isolated global install if you already use pipx
-- virtualenv + pip: project-specific environments
-
-If you already installed via Homebrew and later need extras, uninstall the Homebrew package and reinstall via `uv tool`, `pipx`, or a virtualenv.
-
-## Build And Publish
-
-This docs site is built with MkDocs and published to GitHub Pages.
-
-Local build:
-
-```bash
-pip install -e ".[docs]"
-mkdocs serve
-mkdocs build --strict
-```
-
-Publish path:
-- the `docs-site.yml` workflow builds on pull requests
-- pushes to `main` deploy the site to GitHub Pages
-
-## More Detailed Docs
-
-This site is intentionally concise. For deeper details, use:
-- [README](https://github.com/foldermix/foldermix/blob/main/README.md)
-- [CLI presentation roadmap](cli-presentation-roadmap.md)
-- [Config-first workflows](https://github.com/foldermix/foldermix/blob/main/docs/config-first-workflows.md)
-- [Compliance and safety](https://github.com/foldermix/foldermix/blob/main/docs/compliance-safety.md)
-- [Contributing](https://github.com/foldermix/foldermix/blob/main/CONTRIBUTING.md)

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -11,6 +11,12 @@
 - [Safety And Troubleshooting](safety-and-troubleshooting.md): sensitive-file handling, filters, policy dry-runs, OCR notes, and common fixes.
 - [CLI Presentation Roadmap](cli-presentation-roadmap.md): the M3 documentation and CLI presentation plan.
 
+## Project Docs
+
+- [README](https://github.com/foldermix/foldermix/blob/main/README.md): full repository overview, command reference, report schema, release notes, and developer guide.
+- [Contributing](https://github.com/foldermix/foldermix/blob/main/CONTRIBUTING.md): contribution process and local development expectations.
+- [Maintainer playbook](https://github.com/foldermix/foldermix/blob/main/docs/maintainer-playbook.md): PR triage, release, coverage, and tap troubleshooting.
+
 ## First Command
 
 ```bash

--- a/site-docs/output-formats-and-reports.md
+++ b/site-docs/output-formats-and-reports.md
@@ -1,0 +1,50 @@
+# Output Formats And Reports
+
+Choose the output format based on how the bundle will be read.
+
+## Formats
+
+| Format | Choose it when | Shape |
+|---|---|---|
+| Markdown (`md`) | You want a readable context file to paste into chat, inspect in an editor, or share with a reviewer. | One document with metadata, table of contents, and fenced file blocks. |
+| XML (`xml`) | You want explicit file boundaries for tools or prompts that parse tagged sections. | One `<foldermix>` document with `<header>` metadata and `<files>` containing one `<file>` element per included file. |
+| JSONL (`jsonl`) | You want streaming, indexing, or pipeline-friendly machine input. | One header object followed by one JSON object per included file. |
+
+Examples:
+
+```bash
+foldermix pack . --format md --out context.md
+foldermix pack . --format xml --out context.xml
+foldermix pack . --format jsonl --out context.jsonl
+```
+
+## Reports
+
+Use `--report` when you need a machine-readable audit trail:
+
+```bash
+foldermix pack . --format md --out context.md --report report.json
+```
+
+The report includes high-level run counters and per-file details:
+
+- `schema_version`
+- `included_count`, `skipped_count`, and `total_bytes`
+- `included_files[]`
+- `skipped_files[]`
+- `reason_code_counts`
+- `warning_code_counts`
+- `redaction_summary`
+- `policy_findings`
+- `policy_finding_counts`
+
+## Reason-Code Families
+
+Reports group outcomes into stable families:
+
+- Skip reasons: hidden paths, excluded directories, sensitive files, `.gitignore`, globs, extensions, unreadable paths, oversized files, missing paths, and outside-root stdin entries.
+- Included-file outcomes: truncation, redaction, and conversion warnings.
+- Warning taxonomy: encoding fallback, converter availability, OCR dependency or extraction issues, and unclassified warnings.
+- Policy findings: rule matches, skip-reason matches, content regex matches, and file/count/byte threshold findings.
+
+Use these families to decide whether to adjust filters, install optional converters, enable redaction, or investigate policy findings.

--- a/site-docs/output-formats-and-reports.md
+++ b/site-docs/output-formats-and-reports.md
@@ -38,6 +38,36 @@ The report includes high-level run counters and per-file details:
 - `policy_findings`
 - `policy_finding_counts`
 
+Minimal shape:
+
+```json
+{
+  "schema_version": 5,
+  "included_count": 2,
+  "skipped_count": 1,
+  "total_bytes": 1234,
+  "included_files": [
+    {"path": "README.md", "outcome_codes": []}
+  ],
+  "skipped_files": [
+    {
+      "path": ".env",
+      "reason_code": "SKIP_SENSITIVE",
+      "message": "Path matches a sensitive-file pattern."
+    }
+  ],
+  "reason_code_counts": {"SKIP_SENSITIVE": 1}
+}
+```
+
+Read reports in this order:
+
+1. Check `included_count`, `skipped_count`, and `total_bytes` to confirm the run size.
+2. Review `reason_code_counts` for the most common skip or outcome reasons.
+3. Inspect `skipped_files[]` when expected files are missing.
+4. Inspect `included_files[]` for truncation, redaction, and conversion warnings.
+5. Review `policy_findings[]` and `policy_finding_counts` when policy packs or custom rules are enabled.
+
 ## Reason-Code Families
 
 Reports group outcomes into stable families:

--- a/site-docs/quickstart.md
+++ b/site-docs/quickstart.md
@@ -1,0 +1,74 @@
+# Quickstart
+
+Use this page to install `foldermix`, inspect a folder, and write your first context bundle.
+
+## Install
+
+Recommended default:
+
+```bash
+pip install foldermix
+```
+
+Use the default install for the core CLI and text-like files: plain text, Markdown, source code, config/data files, WebVTT, and notebooks.
+
+Homebrew installs the core CLI only:
+
+```bash
+brew tap foldermix/foldermix
+brew install foldermix
+```
+
+Homebrew does not install optional converter extras. Use a Python tool install when you need PDF, OCR, Office, or `markitdown` support:
+
+```bash
+uv tool install "foldermix[all,markitdown]"
+```
+
+## Pack A Folder
+
+Run from the folder you want to pack:
+
+```bash
+foldermix pack . --out context.md
+```
+
+Expected artifact: `context.md`, a Markdown bundle with run metadata, a table of contents, and fenced file blocks.
+
+Defaults worth knowing:
+
+- Markdown (`md`) is the default output format.
+- If `--out` is omitted, the generated timestamped filename uses the selected format extension.
+- Hidden files and directories are skipped unless `--hidden` is set.
+- `.gitignore` is respected by default.
+
+## Preview Before Packing
+
+Use these commands before producing a bundle:
+
+```bash
+foldermix list .
+foldermix skiplist .
+foldermix stats .
+foldermix preview . README.md
+```
+
+- `list` shows files that would be included.
+- `skiplist` shows files that would be skipped and why.
+- `stats` summarizes selected files by extension and size.
+- `preview` renders selected files through the pack pipeline without writing the full bundle.
+
+## Config-First Quick Path
+
+Use a starter profile when the workflow should be repeatable:
+
+```bash
+foldermix init --profile engineering-docs
+foldermix pack . --config foldermix.toml --format md --out context.md --report report.json
+```
+
+Expected artifacts:
+
+- `foldermix.toml`: editable configuration for future runs.
+- `context.md`: packed Markdown context bundle.
+- `report.json`: machine-readable include/skip and outcome report.

--- a/site-docs/safety-and-troubleshooting.md
+++ b/site-docs/safety-and-troubleshooting.md
@@ -1,0 +1,106 @@
+# Safety And Troubleshooting
+
+`foldermix` is designed for local-folder context packing where users need to inspect what will be included before sharing output.
+
+## Safety Defaults
+
+- Sensitive files such as `.env`, private keys, and certificates are skipped unconditionally.
+- `.gitignore` is respected by default.
+- Hidden files and directories are skipped unless `--hidden` is set.
+- Output ordering is deterministic.
+- Size limits can skip or truncate oversized files depending on configuration.
+
+Inspect before packing:
+
+```bash
+foldermix list . --config foldermix.toml
+foldermix skiplist . --config foldermix.toml
+foldermix stats . --config foldermix.toml
+```
+
+## Filtering And Cleanup
+
+Use include/exclude flags or config settings to narrow the bundle:
+
+```bash
+foldermix pack . --include-ext .md,.py,.toml --out context.md
+foldermix pack . --exclude-dirs node_modules,dist --out context.md
+foldermix pack . --exclude-glob '*.tmp' --out context.md
+```
+
+Use duplicate suppression when exact duplicate content is noisy:
+
+```bash
+foldermix pack ./corpus --dedupe-content --report dedupe-report.json --out deduped-context.md
+```
+
+## Redaction And Policy Preview
+
+Redact emails, phone numbers, or both:
+
+```bash
+foldermix pack . --redact all --out context.md --report report.json
+```
+
+Preview policy outcomes without writing a bundle:
+
+```bash
+foldermix pack . --policy-pack strict-privacy --policy-dry-run
+foldermix pack . --policy-pack strict-privacy --policy-dry-run --policy-output json
+```
+
+Use policy enforcement only when the workflow requires a non-zero exit on findings:
+
+```bash
+foldermix pack . --policy-pack strict-privacy --fail-on-policy-violation --policy-fail-level high --report report.json
+```
+
+## Common Problems
+
+### Expected files are missing
+
+Run:
+
+```bash
+foldermix list . --config foldermix.toml
+foldermix skiplist . --config foldermix.toml
+```
+
+Check `.gitignore`, hidden-path defaults, extension filters, glob filters, size limits, and sensitive-file protection.
+
+### Optional converter warnings appear
+
+Homebrew and the default `pip install foldermix` path do not install optional converter extras. Install the relevant extra through a Python environment:
+
+```bash
+pip install "foldermix[pdf]"
+pip install "foldermix[ocr]"
+pip install "foldermix[office]"
+uv tool install "foldermix[all,markitdown]"
+```
+
+### `--null` fails
+
+`--null` is valid only with `--stdin`:
+
+```bash
+find . -type f -print0 | foldermix pack . --stdin --null --out context.md
+```
+
+### OCR is needed for standalone images
+
+Image files remain excluded by default. Include image extensions explicitly and enable image OCR:
+
+```bash
+foldermix pack . --include-ext .png,.jpg,.jpeg --image-ocr --out image-context.md
+```
+
+### Config values are surprising
+
+Print the effective config and value sources:
+
+```bash
+foldermix pack . --config foldermix.toml --print-effective-config
+foldermix list . --config foldermix.toml --print-effective-config
+foldermix stats . --config foldermix.toml --print-effective-config
+```

--- a/site-docs/workflows.md
+++ b/site-docs/workflows.md
@@ -2,6 +2,8 @@
 
 These cookbook recipes are starting points for common local-folder jobs. Each recipe keeps commands copy-pasteable and names the expected artifact.
 
+Write generated bundles and reports outside the source tree, or exclude previous `context.*`, `*-context.*`, and `*report.json` artifacts with `.gitignore`, `foldermix.toml`, or CLI filters before repeat runs.
+
 ## AI Context Packing
 
 ### When to use it
@@ -21,7 +23,7 @@ foldermix pack . --format md --out context.md --report report.json
 
 ### Safety/filtering note
 
-Sensitive files are skipped unconditionally, `.gitignore` is respected by default, and hidden paths stay out unless `--hidden` is set.
+Sensitive files are skipped unconditionally, `.gitignore` is respected by default, and hidden paths stay out unless `--hidden` is set. Keep generated `context.md` and `report.json` out of later packs.
 
 ## Legal Review Bundles
 

--- a/site-docs/workflows.md
+++ b/site-docs/workflows.md
@@ -1,0 +1,151 @@
+# Workflows
+
+These cookbook recipes are starting points for common local-folder jobs. Each recipe keeps commands copy-pasteable and names the expected artifact.
+
+## AI Context Packing
+
+### When to use it
+
+Use this when you want a readable context bundle for a codebase, docs folder, or mixed project notes.
+
+### Commands
+
+```bash
+foldermix list .
+foldermix pack . --format md --out context.md --report report.json
+```
+
+### Expected artifact
+
+`context.md` for the LLM-facing bundle and `report.json` for the include/skip audit trail.
+
+### Safety/filtering note
+
+Sensitive files are skipped unconditionally, `.gitignore` is respected by default, and hidden paths stay out unless `--hidden` is set.
+
+## Legal Review Bundles
+
+### When to use it
+
+Use this for privacy-sensitive matter folders where redaction, OCR fallback, checksums, and a report are useful.
+
+### Commands
+
+```bash
+foldermix init --profile legal --out foldermix.toml --force
+foldermix pack ./matter --config foldermix.toml --format md --out legal-context.md --report legal-report.json
+```
+
+### Expected artifact
+
+`legal-context.md` for review and `legal-report.json` for traceability.
+
+### Safety/filtering note
+
+The `legal` profile enables full redaction and PDF OCR fallback defaults. Use [Safety And Troubleshooting](safety-and-troubleshooting.md) for policy dry-run and enforcement options when you need stricter gates.
+
+## Research Corpus Bundles
+
+### When to use it
+
+Use this for literature-heavy or mixed-format corpora where machine-readable output is useful downstream.
+
+### Commands
+
+```bash
+foldermix init --profile research --out foldermix.toml --force
+find ./corpus -type f -print0 | foldermix pack ./corpus --config foldermix.toml --stdin --null --format jsonl --out research-context.jsonl --report research-report.json
+```
+
+### Expected artifact
+
+`research-context.jsonl`, with one header object and one JSON object per included file, plus `research-report.json`.
+
+### Safety/filtering note
+
+The `research` profile favors broad recall and email redaction. The explicit `find -print0` pipeline makes the selected input list reproducible.
+
+## Support Incident Bundles
+
+### When to use it
+
+Use this when packing tickets, logs, runbooks, and related notes for incident analysis.
+
+### Commands
+
+```bash
+foldermix init --profile support --out foldermix.toml --force
+printf 'tickets/a.md\ntickets/b.log\n' | foldermix pack . --config foldermix.toml --stdin --format md --out support-context.md --report support-report.json
+```
+
+### Expected artifact
+
+`support-context.md` and `support-report.json`.
+
+### Safety/filtering note
+
+The `support` profile uses full redaction defaults. Prefer explicit stdin lists when only selected tickets or logs should be included.
+
+## Course Refresh Bundles
+
+### When to use it
+
+Use this when preparing prior course material for refresh or reuse while avoiding common student/admin paths.
+
+### Commands
+
+```bash
+foldermix init --profile course-refresh --out foldermix.toml --force
+foldermix pack ./previous-course --config foldermix.toml --format md --out course-refresh-context.md --report course-refresh-report.json
+```
+
+### Expected artifact
+
+`course-refresh-context.md` and `course-refresh-report.json`.
+
+### Safety/filtering note
+
+The `course-refresh` profile excludes common course-admin and student-specific paths such as grades, rosters, responses, feedback, and submissions.
+
+## Config-First Workflows
+
+### When to use it
+
+Use this when a project needs repeatable packing behavior across local runs, reviews, or automation.
+
+### Commands
+
+```bash
+foldermix init --profile engineering-docs --out foldermix.toml --force
+foldermix pack . --config foldermix.toml --print-effective-config
+foldermix list . --config foldermix.toml
+foldermix pack . --config foldermix.toml --format md --out context.md --report report.json
+```
+
+### Expected artifact
+
+`foldermix.toml`, `context.md`, and `report.json`.
+
+### Safety/filtering note
+
+Use `--print-effective-config` to verify which settings came from defaults, config, or CLI flags before writing output.
+
+## Machine-Readable Reports And JSONL Pipelines
+
+### When to use it
+
+Use this when downstream tooling needs structured records or when you want an audit trail for included and skipped files.
+
+### Commands
+
+```bash
+find ./corpus -type f -print0 | foldermix pack ./corpus --stdin --null --format jsonl --out context.jsonl --report report.json
+```
+
+### Expected artifact
+
+`context.jsonl` for streaming or indexing, plus `report.json` for reason codes and outcome summaries.
+
+### Safety/filtering note
+
+JSONL is best for tools that process one object at a time. Use the report to inspect skip reasons, redaction outcomes, conversion warnings, and policy findings.


### PR DESCRIPTION
## Planning notation

- Notation: `DOCS-PRES-3`
- Parent milestone: `M3 CLI Presentation & Docs`
- Plan source: `docs/presentation-roadmap.md`

## Summary

- Expanded the MkDocs navigation from a one-page docs site into dedicated quickstart, workflows, configuration, output formats/reports, and safety/troubleshooting pages.
- Added cookbook recipes for AI context packing, legal review, research corpora, support incidents, course refreshes, config-first runs, and machine-readable `jsonl`/report pipelines.
- Reworked the docs landing page as a concise route map and updated README workflow links to point at the new docs-site guides.

## Impact

- Documentation-only change.
- No CLI behavior, output contracts, report schema, package metadata, tests, scanner behavior, or converter behavior changed.
- Issues #139 and #134 remain out of scope.

## Validation

- `git diff --check`
- `/Users/shaypalachy/.local/bin/uv run --extra docs mkdocs build --strict`
- Commit hook: `pytest-fast`

## Follow-up

- `DOCS-PRES-4` handles CLI help/output presentation and should not be bundled here.
