### PR TITLE
DOCS-PRES-4: Improve CLI output and help presentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
 
           list_out="$(run_expect 0 ./.pkg-smoke-venv/bin/foldermix list smoke_input)"
           assert_contains "$list_out" "a.txt"
-          assert_contains "$list_out" "1 files would be included, 0 skipped."
+          assert_contains "$list_out" "1 file would be included, 0 files skipped."
 
           stats_out="$(run_expect 0 ./.pkg-smoke-venv/bin/foldermix stats smoke_input)"
           assert_contains "$stats_out" "Included files: 1"

--- a/foldermix/cli.py
+++ b/foldermix/cli.py
@@ -19,6 +19,7 @@ from .init_profiles import available_profiles, has_profile, render_profile_confi
 from .report import build_skipped_file_entry
 from .scanner import FileRecord, SkipRecord
 from .stdin_paths import parse_stdin_paths
+from .terminal import print_file_table, print_skip_table, print_stats_table
 
 _INIT_PROFILE_CHOICES = ", ".join(available_profiles())
 
@@ -36,8 +37,9 @@ app = typer.Typer(
         "  version – Print the installed foldermix version.\n\n"
         "Run 'foldermix COMMAND --help' for detailed options on any command.\n\n"
         "Guides:\n\n"
-        "  Config-first workflows: https://github.com/foldermix/foldermix/blob/main/docs/config-first-workflows.md\n\n"
-        "  Compliance & safety:   https://github.com/foldermix/foldermix/blob/main/docs/compliance-safety.md"
+        "  Quickstart: https://foldermix.github.io/foldermix/quickstart/\n\n"
+        "  Workflows:  https://foldermix.github.io/foldermix/workflows/\n\n"
+        "  Safety:     https://foldermix.github.io/foldermix/safety-and-troubleshooting/"
     ),
     add_completion=False,
 )
@@ -710,11 +712,11 @@ def list_cmd(
     Examples:
 
     \b
-      # List all files in the current directory
+      # Show files that would be packed
       foldermix list .
 
     \b
-      # List only Python files, including hidden ones
+      # Focus the scan before packing
       foldermix list . --include-ext .py --hidden
     """
     from .config import PackConfig
@@ -778,8 +780,7 @@ def list_cmd(
         image_ocr=values["image_ocr"],  # type: ignore[arg-type]
     )
     included, skipped = scan(pack_config)
-    for r in included:
-        console.print(f"{r.relpath}  ({r.size:,} bytes)")
+    print_file_table(console, included, title="Included files")
     console.print(f"\n{len(included)} files would be included, {len(skipped)} skipped.")
 
 
@@ -826,6 +827,10 @@ def stats_cmd(
     \b
       # Stats for Python files only
       foldermix stats ./src --include-ext .py
+
+    \b
+      # Stats for an explicit NUL-delimited file list
+      find . -type f -print0 | foldermix stats . --stdin --null
     """
     from .config import PackConfig
     from .scanner import scan
@@ -867,13 +872,14 @@ def stats_cmd(
     for r in included:
         ext_counts[r.ext] = ext_counts.get(r.ext, 0) + 1
 
-    console.print(f"[bold]Stats for {path}[/bold]")
-    console.print(f"  Included files: {len(included)}")
-    console.print(f"  Skipped files:  {len(skipped)}")
-    console.print(f"  Total bytes:    {total_bytes:,}")
-    console.print("\n  [bold]By extension:[/bold]")
-    for ext, count in sorted(ext_counts.items(), key=lambda x: -x[1]):
-        console.print(f"    {ext or '(none)':15s} {count:5d}")
+    print_stats_table(
+        console,
+        title=f"Stats for {path}",
+        included_count=len(included),
+        skipped_count=len(skipped),
+        total_bytes=total_bytes,
+        extension_counts=ext_counts,
+    )
 
 
 @app.command("skiplist")
@@ -970,6 +976,10 @@ def skiplist_cmd(
     \b
       # Include conversion-availability checks
       foldermix skiplist . --conversion-check
+
+    \b
+      # Inspect skipped files after applying config
+      foldermix skiplist . --config foldermix.toml
     """
     from .scanner import scan
 
@@ -1036,11 +1046,7 @@ def skiplist_cmd(
         skipped=skipped,
         conversion_check=conversion_check,
     )
-    for entry in skip_entries:
-        console.print(
-            f"{entry['path']}  [{entry['reason_code']}] {entry['message']}",
-            markup=False,
-        )
+    print_skip_table(console, skip_entries, title="Skipped files")
     if conversion_check:
         console.print(
             "\n"
@@ -1194,6 +1200,10 @@ def preview_cmd(
     \b
       # Preview files from stdin
       printf 'README.md\nsrc/a.py\n' | foldermix preview . --stdin
+
+    \b
+      # Preview with skipped-file diagnostics in Markdown output
+      foldermix preview . README.md --include-skipped-files
     """
     from .packer import render_preview
     from .scanner import scan
@@ -1369,7 +1379,18 @@ def init_cmd(
         help="Overwrite an existing output file. By default existing files are preserved.",
     ),
 ) -> None:
-    """Generate a starter foldermix.toml for common local workflows."""
+    """Generate a starter foldermix.toml for common local workflows.
+
+    Examples:
+
+    \b
+      # Generate an engineering docs starter config
+      foldermix init --profile engineering-docs
+
+    \b
+      # Overwrite an existing config intentionally
+      foldermix init --profile legal --out foldermix.toml --force
+    """
     normalized = profile.strip().lower()
     if not has_profile(normalized):
         valid = ", ".join(available_profiles())
@@ -1404,7 +1425,7 @@ def init_cmd(
 
 @app.command("version")
 def version_cmd() -> None:
-    """Print the version."""
+    """Print the installed foldermix version."""
     console.print(f"foldermix {__version__}")
 
 

--- a/foldermix/cli.py
+++ b/foldermix/cli.py
@@ -19,7 +19,7 @@ from .init_profiles import available_profiles, has_profile, render_profile_confi
 from .report import build_skipped_file_entry
 from .scanner import FileRecord, SkipRecord
 from .stdin_paths import parse_stdin_paths
-from .terminal import print_file_table, print_skip_table, print_stats_table
+from .terminal import format_count, print_file_table, print_skip_table, print_stats_table
 
 _INIT_PROFILE_CHOICES = ", ".join(available_profiles())
 
@@ -781,7 +781,10 @@ def list_cmd(
     )
     included, skipped = scan(pack_config)
     print_file_table(console, included, title="Included files")
-    console.print(f"\n{len(included)} files would be included, {len(skipped)} skipped.")
+    console.print(
+        f"\n{format_count(len(included), 'file')} would be included, "
+        f"{format_count(len(skipped), 'file')} skipped."
+    )
 
 
 @app.command("stats")
@@ -1048,13 +1051,15 @@ def skiplist_cmd(
     )
     print_skip_table(console, skip_entries, title="Skipped files")
     if conversion_check:
+        converter_verb = "lacks" if converter_missing_count == 1 else "lack"
         console.print(
             "\n"
-            f"{len(skipped)} files would be skipped by scanning; "
-            f"{converter_missing_count} additional files currently lack a supported converter."
+            f"{format_count(len(skipped), 'file')} would be skipped by scanning; "
+            f"{format_count(converter_missing_count, 'additional file')} "
+            f"currently {converter_verb} a supported converter."
         )
     else:
-        console.print(f"\n{len(skip_entries)} files would be skipped.")
+        console.print(f"\n{format_count(len(skip_entries), 'file')} would be skipped.")
 
 
 @app.command("preview")

--- a/foldermix/packer.py
+++ b/foldermix/packer.py
@@ -28,7 +28,7 @@ from .report import (
     write_report,
 )
 from .scanner import FileRecord, SkipRecord, scan
-from .terminal import print_file_table
+from .terminal import format_count, print_file_table
 from .utils import (
     drop_lines_containing,
     drop_lines_shorter_than,
@@ -619,7 +619,9 @@ def pack(config: PackConfig) -> None:
 
     if config.dry_run:
         print_file_table(console, included, title="Files that would be packed")
-        console.print(f"\n[bold]Dry run complete.[/bold] Would pack {len(included)} files.")
+        console.print(
+            f"\n[bold]Dry run complete.[/bold] Would pack {format_count(len(included), 'file')}."
+        )
         return
 
     registry = _build_registry(config)

--- a/foldermix/packer.py
+++ b/foldermix/packer.py
@@ -28,6 +28,7 @@ from .report import (
     write_report,
 )
 from .scanner import FileRecord, SkipRecord, scan
+from .terminal import print_file_table
 from .utils import (
     drop_lines_containing,
     drop_lines_shorter_than,
@@ -617,8 +618,7 @@ def pack(config: PackConfig) -> None:
         raise typer.Exit(code=3)
 
     if config.dry_run:
-        for r in included:
-            console.print(f"  [cyan]{r.relpath}[/cyan] ({r.size:,} bytes)")
+        print_file_table(console, included, title="Files that would be packed")
         console.print(f"\n[bold]Dry run complete.[/bold] Would pack {len(included)} files.")
         return
 

--- a/foldermix/terminal.py
+++ b/foldermix/terminal.py
@@ -8,8 +8,13 @@ from rich.table import Table
 from rich.text import Text
 
 
+def format_count(count: int, singular: str, plural: str | None = None) -> str:
+    label = singular if count == 1 else plural or f"{singular}s"
+    return f"{count:,} {label}"
+
+
 def format_bytes(size: int) -> str:
-    return f"{size:,} bytes"
+    return format_count(size, "byte")
 
 
 def print_file_table(
@@ -67,7 +72,7 @@ def print_stats_table(
     table.add_column("Extension")
     table.add_column("Files", justify="right")
 
-    for ext, count in sorted(extension_counts.items(), key=lambda item: (-item[1], item[0])):
+    for ext, count in sorted(extension_counts.items(), key=lambda item: -item[1]):
         table.add_row(ext or "(none)", str(count))
 
     console.print()

--- a/foldermix/terminal.py
+++ b/foldermix/terminal.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from rich import box
+from rich.console import Console
+from rich.table import Table
+from rich.text import Text
+
+
+def format_bytes(size: int) -> str:
+    return f"{size:,} bytes"
+
+
+def print_file_table(
+    console: Console,
+    records: Iterable[object],
+    *,
+    title: str,
+    path_attr: str = "relpath",
+    size_attr: str = "size",
+) -> None:
+    table = Table(title=title, box=box.SIMPLE, show_lines=False)
+    table.add_column("Path", overflow="fold")
+    table.add_column("Size", justify="right")
+
+    for record in records:
+        table.add_row(
+            Text(str(getattr(record, path_attr))),
+            format_bytes(int(getattr(record, size_attr))),
+        )
+
+    console.print(table)
+
+
+def print_skip_table(console: Console, entries: Iterable[dict[str, str]], *, title: str) -> None:
+    table = Table(title=title, box=box.SIMPLE, show_lines=False)
+    table.add_column("Path", overflow="fold")
+    table.add_column("Reason code", no_wrap=True)
+    table.add_column("Message", overflow="fold")
+
+    for entry in entries:
+        table.add_row(
+            Text(entry["path"]),
+            Text(entry["reason_code"]),
+            Text(entry["message"]),
+        )
+
+    console.print(table)
+
+
+def print_stats_table(
+    console: Console,
+    *,
+    title: str,
+    included_count: int,
+    skipped_count: int,
+    total_bytes: int,
+    extension_counts: dict[str, int],
+) -> None:
+    console.print(f"[bold]{title}[/bold]")
+    console.print(f"Included files: {included_count}")
+    console.print(f"Skipped files:  {skipped_count}")
+    console.print(f"Total bytes:    {total_bytes:,}")
+
+    table = Table(title="By extension", box=box.SIMPLE, show_lines=False)
+    table.add_column("Extension")
+    table.add_column("Files", justify="right")
+
+    for ext, count in sorted(extension_counts.items(), key=lambda item: (-item[1], item[0])):
+        table.add_row(ext or "(none)", str(count))
+
+    console.print()
+    console.print(table)

--- a/site-docs/quickstart.md
+++ b/site-docs/quickstart.md
@@ -58,6 +58,8 @@ foldermix preview . README.md
 - `stats` summarizes selected files by extension and size.
 - `preview` renders selected files through the pack pipeline without writing the full bundle.
 
+`list`, `skiplist`, and `stats` print table-style summaries so include/skip decisions are easier to scan before packing.
+
 ## Config-First Quick Path
 
 Use a starter profile when the workflow should be repeatable:

--- a/site-docs/safety-and-troubleshooting.md
+++ b/site-docs/safety-and-troubleshooting.md
@@ -18,6 +18,8 @@ foldermix skiplist . --config foldermix.toml
 foldermix stats . --config foldermix.toml
 ```
 
+These commands print table-style summaries for included files, skipped files, and extension counts.
+
 ## Filtering And Cleanup
 
 Use include/exclude flags or config settings to narrow the bundle:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -777,7 +777,7 @@ def test_skiplist_conversion_check_reports_unsupported_extensions(tmp_path: Path
     assert "custom.weird" in result.output
     assert "files without" in result.output
     assert "an extension" in result.output
-    assert "extension '.weird'" in result.output
+    assert ".weird" in result.output
 
 
 def test_skiplist_conversion_check_uses_real_converter_registry(tmp_path: Path) -> None:
@@ -1459,6 +1459,42 @@ def test_stats_prints_summary_and_extensions(tmp_path: Path) -> None:
     assert "Skipped files:  0" in result.output
     assert ".py" in result.output
     assert ".md" in result.output
+    assert "By extension" in result.output
+    assert "Extension" in result.output
+    assert "Files" in result.output
+
+
+def test_list_prints_table_with_summary(tmp_path: Path) -> None:
+    (tmp_path / "a.txt").write_text("a\n", encoding="utf-8")
+    (tmp_path / "b.md").write_text("# b\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["list", str(tmp_path)])
+
+    assert result.exit_code == 0, result.output
+    assert "Included files" in result.output
+    assert "Path" in result.output
+    assert "Size" in result.output
+    assert "a.txt" in result.output
+    assert "2 bytes" in result.output
+    assert "b.md" in result.output
+    assert "4 bytes" in result.output
+    assert "2 files would be included, 0 skipped." in result.output
+
+
+def test_skiplist_prints_table_with_reason_codes(tmp_path: Path) -> None:
+    (tmp_path / "keep.txt").write_text("ok", encoding="utf-8")
+    (tmp_path / ".hidden").write_text("secret", encoding="utf-8")
+
+    result = runner.invoke(app, ["skiplist", str(tmp_path)])
+
+    assert result.exit_code == 0, result.output
+    assert "Skipped files" in result.output
+    assert "Path" in result.output
+    assert "Reason code" in result.output
+    assert "Message" in result.output
+    assert ".hidden" in result.output
+    assert "SKIP_HIDDEN" in result.output
+    assert "1 files would be skipped." in result.output
 
 
 def test_stats_reports_invalid_config(tmp_path: Path) -> None:
@@ -1500,6 +1536,20 @@ def test_pack_help_contains_examples() -> None:
     # \b blocks preserve the comment text verbatim
     assert "Pack current directory to Markdown" in result.output
     assert "Dry-run" in result.output
+
+
+def test_init_help_contains_examples() -> None:
+    result = runner.invoke(app, ["init", "--help"])
+    assert result.exit_code == 0
+    assert "Examples:" in result.output
+    assert "foldermix init --profile engineering-docs" in result.output
+    assert "foldermix init --profile legal" in result.output
+
+
+def test_version_help_is_concise_and_accurate() -> None:
+    result = runner.invoke(app, ["version", "--help"])
+    assert result.exit_code == 0
+    assert "Print the installed foldermix version." in result.output
 
 
 def test_pack_help_all_options_documented(tmp_path: Path) -> None:
@@ -1597,6 +1647,7 @@ def test_stats_help_all_options_documented() -> None:
     assert "--stdin" in output
     assert "--null" in output
     assert "Examples:" in output
+    assert "find . -type f -print0" in output
 
 
 def test_root_help_lists_all_commands() -> None:
@@ -1610,4 +1661,6 @@ def test_root_help_lists_all_commands() -> None:
     assert "stats" in result.output
     assert "version" in result.output
     assert "foldermix COMMAND" in result.output
-    assert "github.com/foldermix/foldermix/blob/main/docs/compliance-safety.md" in result.output
+    assert "foldermix.github.io/foldermix/quickstart" in result.output
+    assert "foldermix.github.io/foldermix/workflows" in result.output
+    assert "foldermix.github.io/foldermix/safety-and-troubleshooting" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,7 @@ import foldermix.scanner as scanner_module
 from foldermix import __version__
 from foldermix import cli as cli_module
 from foldermix.cli import app
+from foldermix.terminal import format_bytes, format_count
 
 runner = CliRunner()
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
@@ -18,6 +19,15 @@ _ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
 
 def _strip_ansi(text: str) -> str:
     return _ANSI_RE.sub("", text)
+
+
+def test_terminal_count_formatting_handles_singular_and_plural() -> None:
+    assert format_count(1, "file") == "1 file"
+    assert format_count(2, "file") == "2 files"
+    assert format_count(1, "additional file") == "1 additional file"
+    assert format_count(0, "additional file") == "0 additional files"
+    assert format_bytes(1) == "1 byte"
+    assert format_bytes(2) == "2 bytes"
 
 
 def test_pack_rejects_invalid_format(tmp_path: Path) -> None:
@@ -600,7 +610,7 @@ def test_list_shows_included_and_skipped_files(tmp_path: Path) -> None:
     assert result.exit_code == 0, result.output
     assert "keep.txt" in result.output
     assert ".hidden" not in result.output
-    assert "1 files would be included, 1 skipped." in result.output
+    assert "1 file would be included, 1 file skipped." in result.output
 
 
 def test_list_rejects_invalid_on_oversize(tmp_path: Path) -> None:
@@ -665,7 +675,7 @@ def test_list_reports_glob_excluded_files_from_pack_config(tmp_path: Path) -> No
     assert result.exit_code == 0, result.output
     assert "keep.txt" in result.output
     assert "skip.tmp" not in result.output
-    assert "1 files would be included, 1 skipped." in result.output
+    assert "1 file would be included, 1 file skipped." in result.output
 
 
 def test_list_honors_include_glob_override_from_pack_config(tmp_path: Path) -> None:
@@ -691,7 +701,7 @@ def test_list_honors_include_glob_override_from_pack_config(tmp_path: Path) -> N
     assert result.exit_code == 0, result.output
     assert "keep.txt" in result.output
     assert "skip.txt" not in result.output
-    assert "1 files would be included, 1 skipped." in result.output
+    assert "1 file would be included, 1 file skipped." in result.output
 
 
 def test_list_honors_exclude_dirs_from_pack_config(tmp_path: Path) -> None:
@@ -719,7 +729,7 @@ def test_list_honors_exclude_dirs_from_pack_config(tmp_path: Path) -> None:
     assert result.exit_code == 0, result.output
     assert "ok.txt" in result.output
     assert "blocked/note.txt" not in result.output
-    assert "1 files would be included, 0 skipped." in result.output
+    assert "1 file would be included, 0 files skipped." in result.output
 
 
 def test_skiplist_shows_skipped_files_with_reason_codes(tmp_path: Path) -> None:
@@ -732,7 +742,7 @@ def test_skiplist_shows_skipped_files_with_reason_codes(tmp_path: Path) -> None:
     assert ".hidden" in result.output
     assert "SKIP_HIDDEN" in result.output
     assert "keep.txt" not in result.output
-    assert "1 files would be skipped." in result.output
+    assert "1 file would be skipped." in result.output
 
 
 def test_skiplist_conversion_check_reports_missing_optional_dependency(
@@ -754,6 +764,8 @@ def test_skiplist_conversion_check_reports_missing_optional_dependency(
     assert "doc.pdf" in result.output
     assert "SKIP_OPTIONAL_DEPENDENCY_MISSING" in result.output
     assert "foldermix[pdf]" in result.output
+    assert "1 additional file currently lacks a" in result.output
+    assert "supported converter." in result.output
 
 
 def test_skiplist_conversion_check_reports_unsupported_extensions(tmp_path: Path) -> None:
@@ -1465,8 +1477,8 @@ def test_stats_prints_summary_and_extensions(tmp_path: Path) -> None:
 
 
 def test_list_prints_table_with_summary(tmp_path: Path) -> None:
-    (tmp_path / "a.txt").write_text("a\n", encoding="utf-8")
-    (tmp_path / "b.md").write_text("# b\n", encoding="utf-8")
+    (tmp_path / "a.txt").write_bytes(b"a\n")
+    (tmp_path / "b.md").write_bytes(b"# b\n")
 
     result = runner.invoke(app, ["list", str(tmp_path)])
 
@@ -1478,7 +1490,7 @@ def test_list_prints_table_with_summary(tmp_path: Path) -> None:
     assert "2 bytes" in result.output
     assert "b.md" in result.output
     assert "4 bytes" in result.output
-    assert "2 files would be included, 0 skipped." in result.output
+    assert "2 files would be included, 0 files skipped." in result.output
 
 
 def test_skiplist_prints_table_with_reason_codes(tmp_path: Path) -> None:
@@ -1494,7 +1506,7 @@ def test_skiplist_prints_table_with_reason_codes(tmp_path: Path) -> None:
     assert "Message" in result.output
     assert ".hidden" in result.output
     assert "SKIP_HIDDEN" in result.output
-    assert "1 files would be skipped." in result.output
+    assert "1 file would be skipped." in result.output
 
 
 def test_stats_reports_invalid_config(tmp_path: Path) -> None:
@@ -1541,9 +1553,10 @@ def test_pack_help_contains_examples() -> None:
 def test_init_help_contains_examples() -> None:
     result = runner.invoke(app, ["init", "--help"])
     assert result.exit_code == 0
-    assert "Examples:" in result.output
-    assert "foldermix init --profile engineering-docs" in result.output
-    assert "foldermix init --profile legal" in result.output
+    output = _strip_ansi(result.output)
+    assert "Examples:" in output
+    assert "foldermix init --profile engineering-docs" in output
+    assert "foldermix init --profile legal" in output
 
 
 def test_version_help_is_concise_and_accurate() -> None:

--- a/tests/test_cli_stdin.py
+++ b/tests/test_cli_stdin.py
@@ -96,7 +96,7 @@ def test_list_and_stats_stdin_use_only_explicit_paths(monkeypatch, tmp_path: Pat
     assert "a.txt" in list_result.output
     assert "c.txt" in list_result.output
     assert "b.txt" not in list_result.output
-    assert "2 files would be included, 1 skipped." in list_result.output
+    assert "2 files would be included, 1 file skipped." in list_result.output
 
     stats_result = runner.invoke(
         app,

--- a/tests/test_cli_stdin.py
+++ b/tests/test_cli_stdin.py
@@ -90,6 +90,9 @@ def test_list_and_stats_stdin_use_only_explicit_paths(monkeypatch, tmp_path: Pat
         input="a.txt\nc.txt\nmissing.txt\n",
     )
     assert list_result.exit_code == 0, list_result.output
+    assert "Included files" in list_result.output
+    assert "Path" in list_result.output
+    assert "Size" in list_result.output
     assert "a.txt" in list_result.output
     assert "c.txt" in list_result.output
     assert "b.txt" not in list_result.output
@@ -104,6 +107,7 @@ def test_list_and_stats_stdin_use_only_explicit_paths(monkeypatch, tmp_path: Pat
     assert "Included files: 2" in stats_result.output
     assert "Skipped files:  1" in stats_result.output
     assert "Total bytes:    3" in stats_result.output
+    assert "By extension" in stats_result.output
 
 
 @pytest.mark.parametrize("command", ["pack", "list", "stats"])

--- a/tests/test_packer.py
+++ b/tests/test_packer.py
@@ -60,7 +60,7 @@ def test_pack_dry_run_does_not_write_output(tmp_path: Path) -> None:
 
 
 def test_pack_dry_run_prints_table(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
-    _write(tmp_path / "a.txt", "hello\n")
+    (tmp_path / "a.txt").write_bytes(b"hello\n")
     config = PackConfig(root=tmp_path, dry_run=True, workers=1)
 
     packer.pack(config)
@@ -72,7 +72,7 @@ def test_pack_dry_run_prints_table(tmp_path: Path, capsys: pytest.CaptureFixture
     assert "a.txt" in captured.err
     assert "6 bytes" in captured.err
     assert "Dry run complete." in captured.err
-    assert "Would pack 1 files." in captured.err
+    assert "Would pack 1 file." in captured.err
 
 
 def test_pack_policy_dry_run_text_summarizes_findings_and_skips_output(

--- a/tests/test_packer.py
+++ b/tests/test_packer.py
@@ -59,6 +59,22 @@ def test_pack_dry_run_does_not_write_output(tmp_path: Path) -> None:
     assert not out_path.exists()
 
 
+def test_pack_dry_run_prints_table(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    _write(tmp_path / "a.txt", "hello\n")
+    config = PackConfig(root=tmp_path, dry_run=True, workers=1)
+
+    packer.pack(config)
+
+    captured = capsys.readouterr()
+    assert "Files that would" in captured.err
+    assert "Path" in captured.err
+    assert "Size" in captured.err
+    assert "a.txt" in captured.err
+    assert "6 bytes" in captured.err
+    assert "Dry run complete." in captured.err
+    assert "Would pack 1 files." in captured.err
+
+
 def test_pack_policy_dry_run_text_summarizes_findings_and_skips_output(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:


### PR DESCRIPTION
## Planning notation
- Notation: `DOCS-PRES-4`
- Parent milestone: `M3 CLI Presentation & Docs`
- Plan source: `docs/presentation-roadmap.md`

## Summary
- Added a small Rich-based terminal presentation helper for table rendering and byte formatting.
- Improved human-readable output for `list`, `skiplist`, `stats`, and `pack --dry-run`.
- Refined CLI help/examples and root guide links for the M3 docs-site pages.
- Updated focused docs-site notes and tests for the new table-style output.

## Impact
- Human-facing CLI output changes for discovery commands and dry-run previews.
- No packed Markdown/XML/JSONL output changes.
- No JSON report schema, policy dry-run JSON, scanner ordering, skip reason code, optional converter, option name, or config key changes.
- Issues #139 and #134 remain out of scope.

## Validation
- `ruff check .`
- `ruff format --check .`
- `pytest -m "not integration and not slow" -o addopts=`
- `uv run --extra docs mkdocs build --strict`
- `git diff --check`

## Follow-up
- M3 planned PR sequence is complete after `DOCS-PRES-4`.
