### PR TITLE
Prefer CLI over MCP in agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,7 +177,7 @@ Use [docs/presentation-roadmap.md](docs/presentation-roadmap.md) as the canonica
 ## PR completion gate
 - Treat feature work and PR work as incomplete until a properly labeled, non-draft GitHub PR with a detailed description is open.
 - Assign the PR to an appropriate milestone when one exists for the work.
-- Prefer GitHub MCP tools for PR creation and metadata updates; use `gh` only for actions those tools do not support cleanly, such as creating missing labels or milestones.
+- Use standard `git` and `gh` CLI first for repository and GitHub work; use git/GitHub MCP tools only for CLI gaps, unavailable CLI, or explicit user request.
 
 ## PR expectations
 - Keep PR descriptions explicit: behavior change, flags and config keys, dependency impact, and test evidence.

--- a/LOCAL_AGENTS.example.md
+++ b/LOCAL_AGENTS.example.md
@@ -4,9 +4,10 @@ Copy this file to `LOCAL_AGENTS.md` for machine-specific agent instructions.
 `LOCAL_AGENTS.md` is intentionally untracked.
 
 ## Optional local MCP routing
-- For this repo, prefer a local git MCP namespace like `mcp__git_<your_server>__*` (replace `<your_server>` with your local MCP server name).
-- Use GitHub MCP for remote operations.
+- Use standard `git` and `gh` CLI first for repository and GitHub work.
+- Use git/GitHub MCP tools only for CLI gaps, unavailable CLI, or explicit user request.
+- If an MCP is needed for this repo, use a local git MCP namespace like `mcp__git_<your_server>__*` (replace `<your_server>` with your local MCP server name) and the matching GitHub MCP.
 
 ## Optional local workflow preferences
-- Prefer MCP tools over shell when both are available.
+- Prefer standard CLI tools over MCP tools when both are available and equivalent.
 - Use local Python environment and tooling preferences as needed.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -236,7 +236,7 @@ See the [Release PR Process](../README.md#release-pr-process) section in README.
 
 - Treat feature work and PR work as incomplete until a properly labeled, non-draft GitHub PR with a detailed description is open.
 - Assign a relevant milestone when one exists.
-- Prefer GitHub MCP tools for PR creation and metadata updates; use `gh` only for unsupported actions such as creating missing labels or milestones.
+- Use standard `git` and `gh` CLI first for repository and GitHub work; use git/GitHub MCP tools only for CLI gaps, unavailable CLI, or explicit user request.
 
 ---
 


### PR DESCRIPTION
## Summary
- Update agent instructions to prefer standard git and gh CLI for repository and GitHub work
- Limit git/GitHub MCP usage to CLI gaps, unavailable CLI, or explicit user request

## Testing
- Not run; documentation-only instruction cleanup.