### PR TITLE
Improve Rich CLI preview and pack output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,8 @@ jobs:
           assert_contains "$list_out" "1 file would be included, 0 files skipped."
 
           stats_out="$(run_expect 0 ./.pkg-smoke-venv/bin/foldermix stats smoke_input)"
-          assert_contains "$stats_out" "Included files: 1"
+          assert_contains "$stats_out" "Included files"
+          assert_contains "$stats_out" "1 file"
           assert_contains "$stats_out" ".txt"
 
           pack_out="$(run_expect 0 ./.pkg-smoke-venv/bin/foldermix pack smoke_input --out smoke_output.md)"

--- a/foldermix/cli.py
+++ b/foldermix/cli.py
@@ -19,7 +19,13 @@ from .init_profiles import available_profiles, has_profile, render_profile_confi
 from .report import build_skipped_file_entry
 from .scanner import FileRecord, SkipRecord
 from .stdin_paths import parse_stdin_paths
-from .terminal import format_count, print_file_table, print_skip_table, print_stats_table
+from .terminal import (
+    format_count,
+    print_file_table,
+    print_preview_summary,
+    print_skip_table,
+    print_stats_table,
+)
 
 _INIT_PROFILE_CHOICES = ", ".join(available_profiles())
 
@@ -785,6 +791,7 @@ def list_cmd(
         f"\n{format_count(len(included), 'file')} would be included, "
         f"{format_count(len(skipped), 'file')} skipped."
     )
+    print_preview_summary(console, included_count=len(included), skipped_count=len(skipped))
 
 
 @app.command("stats")
@@ -1058,8 +1065,19 @@ def skiplist_cmd(
             f"{format_count(converter_missing_count, 'additional file')} "
             f"currently {converter_verb} a supported converter."
         )
+        print_preview_summary(
+            console,
+            included_count=len(included),
+            skipped_count=len(skipped),
+            converter_missing_count=converter_missing_count,
+        )
     else:
         console.print(f"\n{format_count(len(skip_entries), 'file')} would be skipped.")
+        print_preview_summary(
+            console,
+            included_count=len(included),
+            skipped_count=len(skip_entries),
+        )
 
 
 @app.command("preview")

--- a/foldermix/cli.py
+++ b/foldermix/cli.py
@@ -786,7 +786,7 @@ def list_cmd(
         image_ocr=values["image_ocr"],  # type: ignore[arg-type]
     )
     included, skipped = scan(pack_config)
-    print_file_table(console, included, title="Included files")
+    print_file_table(console, included, title="📦 Included files")
     console.print(
         f"\n{format_count(len(included), 'file')} would be included, "
         f"{format_count(len(skipped), 'file')} skipped."
@@ -1056,7 +1056,7 @@ def skiplist_cmd(
         skipped=skipped,
         conversion_check=conversion_check,
     )
-    print_skip_table(console, skip_entries, title="Skipped files")
+    print_skip_table(console, skip_entries, title="⏭ Skipped files")
     if conversion_check:
         converter_verb = "lacks" if converter_missing_count == 1 else "lack"
         console.print(

--- a/foldermix/packer.py
+++ b/foldermix/packer.py
@@ -33,7 +33,6 @@ from .terminal import (
     print_file_table,
     print_pack_result,
     print_pack_scan_summary,
-    print_pack_start,
 )
 from .utils import (
     drop_lines_containing,
@@ -584,7 +583,7 @@ def pack(config: PackConfig) -> None:
 
     policy_findings = []
 
-    print_pack_start(console, root=config.root, output_format=config.format)
+    console.print(f"[bold]Scanning[/bold] {config.root} ...")
     included, skipped = scan(config)
 
     duplicate_skip_count = 0
@@ -592,10 +591,6 @@ def pack(config: PackConfig) -> None:
         included, duplicate_skips = _dedupe_included_records_by_content(included)
         skipped.extend(duplicate_skips)
         duplicate_skip_count = len(duplicate_skips)
-        if duplicate_skips:
-            console.print(
-                f"[yellow]Skipped duplicate-content files:[/yellow] {len(duplicate_skips)}"
-            )
 
     print_pack_scan_summary(
         console,
@@ -629,7 +624,7 @@ def pack(config: PackConfig) -> None:
         raise typer.Exit(code=3)
 
     if config.dry_run:
-        print_file_table(console, included, title="Files that would be packed")
+        print_file_table(console, included, title="📦 Files that would be packed")
         console.print(
             f"\n[bold]Dry run complete.[/bold] Would pack {format_count(len(included), 'file')}."
         )
@@ -813,7 +808,6 @@ def pack(config: PackConfig) -> None:
     print_pack_result(
         console,
         output_path=out_path,
-        output_format=config.format,
         file_count=len(items),
         skipped_count=len(skipped),
         total_bytes=total_bytes,

--- a/foldermix/packer.py
+++ b/foldermix/packer.py
@@ -28,7 +28,13 @@ from .report import (
     write_report,
 )
 from .scanner import FileRecord, SkipRecord, scan
-from .terminal import format_count, print_file_table
+from .terminal import (
+    format_count,
+    print_file_table,
+    print_pack_result,
+    print_pack_scan_summary,
+    print_pack_start,
+)
 from .utils import (
     drop_lines_containing,
     drop_lines_shorter_than,
@@ -578,19 +584,24 @@ def pack(config: PackConfig) -> None:
 
     policy_findings = []
 
-    console.print(f"[bold]Scanning[/bold] {config.root} ...")
+    print_pack_start(console, root=config.root, output_format=config.format)
     included, skipped = scan(config)
 
+    duplicate_skip_count = 0
     if config.dedupe_content:
         included, duplicate_skips = _dedupe_included_records_by_content(included)
         skipped.extend(duplicate_skips)
+        duplicate_skip_count = len(duplicate_skips)
         if duplicate_skips:
             console.print(
                 f"[yellow]Skipped duplicate-content files:[/yellow] {len(duplicate_skips)}"
             )
 
-    console.print(
-        f"Found [green]{len(included)}[/green] files, [yellow]{len(skipped)}[/yellow] skipped"
+    print_pack_scan_summary(
+        console,
+        included_count=len(included),
+        skipped_count=len(skipped),
+        duplicate_skip_count=duplicate_skip_count,
     )
 
     if policy_evaluator is not None:
@@ -785,7 +796,7 @@ def pack(config: PackConfig) -> None:
         ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
         out_path = Path(f"foldermix_{ts}.{ext_map[config.format]}")
 
-    console.print(f"Writing to [bold]{out_path}[/bold] ...")
+    console.print(f"Writing to [bold cyan]{out_path}[/bold cyan] ...")
 
     with open(out_path, "w", encoding="utf-8", newline="") as f:
         if config.include_skipped_files:
@@ -799,6 +810,16 @@ def pack(config: PackConfig) -> None:
             writer.write(f, header, items)
 
     console.print(f"[green]Done![/green] {len(items)} files, {total_bytes:,} bytes -> {out_path}")
+    print_pack_result(
+        console,
+        output_path=out_path,
+        output_format=config.format,
+        file_count=len(items),
+        skipped_count=len(skipped),
+        total_bytes=total_bytes,
+        report_path=config.report,
+        policy_finding_count=(int(policy_counts["total"]) if policy_counts is not None else None),
+    )
 
     _write_report_if_requested(
         config=config,

--- a/foldermix/terminal.py
+++ b/foldermix/terminal.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from pathlib import Path
 
 from rich import box
 from rich.console import Console
@@ -18,6 +19,14 @@ def format_bytes(size: int) -> str:
     return format_count(size, "byte")
 
 
+def format_size(size: int) -> str:
+    """Human-readable file size: B / KB / MB / GB."""
+    for unit, threshold in (("GB", 1 << 30), ("MB", 1 << 20), ("KB", 1 << 10)):
+        if size >= threshold:
+            return f"{size / threshold:.1f} {unit}"
+    return format_bytes(size)
+
+
 def print_file_table(
     console: Console,
     records: Iterable[object],
@@ -27,7 +36,7 @@ def print_file_table(
     size_attr: str = "size",
 ) -> None:
     table = Table(
-        title=f"📦 {title}",
+        title=title,
         title_style="bold cyan",
         box=box.ROUNDED,
         border_style="bright_black",
@@ -41,7 +50,7 @@ def print_file_table(
     for record in records:
         table.add_row(
             Text(str(getattr(record, path_attr))),
-            format_bytes(int(getattr(record, size_attr))),
+            format_size(int(getattr(record, size_attr))),
         )
 
     console.print(table)
@@ -49,7 +58,7 @@ def print_file_table(
 
 def print_skip_table(console: Console, entries: Iterable[dict[str, str]], *, title: str) -> None:
     table = Table(
-        title=f"⏭ {title}",
+        title=title,
         title_style="bold yellow",
         box=box.ROUNDED,
         border_style="bright_black",
@@ -97,18 +106,6 @@ def print_preview_summary(
     )
 
 
-def print_pack_start(console: Console, *, root: object, output_format: str) -> None:
-    console.print(
-        Panel(
-            f"[bold white]Root:[/bold white] {root}\n"
-            f"[bold white]Format:[/bold white] [cyan]{output_format}[/cyan]",
-            title="[bold cyan]foldermix pack[/bold cyan]",
-            border_style="cyan",
-            padding=(0, 1),
-        )
-    )
-
-
 def print_pack_scan_summary(
     console: Console,
     *,
@@ -138,12 +135,11 @@ def print_pack_scan_summary(
 def print_pack_result(
     console: Console,
     *,
-    output_path: object,
-    output_format: str,
+    output_path: Path | str,
     file_count: int,
     skipped_count: int,
     total_bytes: int,
-    report_path: object | None = None,
+    report_path: Path | str | None = None,
     policy_finding_count: int | None = None,
 ) -> None:
     table = Table(
@@ -157,26 +153,15 @@ def print_pack_result(
     table.add_column("Field", style="bold cyan", no_wrap=True)
     table.add_column("Value", style="white", overflow="fold")
     table.add_row("Output", str(output_path))
-    table.add_row("Format", output_format)
     table.add_row("Packed files", format_count(file_count, "file"))
     table.add_row("Skipped files", format_count(skipped_count, "file"))
-    table.add_row("Input bytes", format_bytes(total_bytes))
+    table.add_row("Output size", format_size(total_bytes))
     if report_path is not None:
         table.add_row("Report", str(report_path))
     if policy_finding_count is not None:
         table.add_row("Policy findings", str(policy_finding_count))
 
     console.print(table)
-    console.print(
-        Panel(
-            f"[bold green]{format_count(file_count, 'file')}[/bold green] packed • "
-            f"[bold yellow]{format_count(skipped_count, 'file')}[/bold yellow] skipped • "
-            f"[bold cyan]{format_bytes(total_bytes)}[/bold cyan] -> [bold]{output_path}[/bold]",
-            title="[bold green]Ready[/bold green]",
-            border_style="green",
-            padding=(0, 1),
-        )
-    )
 
 
 def print_stats_table(
@@ -188,17 +173,34 @@ def print_stats_table(
     total_bytes: int,
     extension_counts: dict[str, int],
 ) -> None:
-    console.print(f"[bold]{title}[/bold]")
-    console.print(f"Included files: {included_count}")
-    console.print(f"Skipped files:  {skipped_count}")
-    console.print(f"Total bytes:    {total_bytes:,}")
+    summary = Table(
+        title=title,
+        title_style="bold cyan",
+        box=box.ROUNDED,
+        border_style="bright_black",
+        header_style="bold white on dark_green",
+        show_lines=False,
+    )
+    summary.add_column("Metric", style="bold cyan", no_wrap=True)
+    summary.add_column("Value", style="white")
+    summary.add_row("Included files", format_count(included_count, "file"))
+    summary.add_row("Skipped files", format_count(skipped_count, "file"))
+    summary.add_row("Total size", format_size(total_bytes))
+    console.print(summary)
 
-    table = Table(title="By extension", box=box.SIMPLE, show_lines=False)
-    table.add_column("Extension")
-    table.add_column("Files", justify="right")
+    ext_table = Table(
+        title="By extension",
+        title_style="bold cyan",
+        box=box.ROUNDED,
+        border_style="bright_black",
+        header_style="bold white on dark_green",
+        show_lines=False,
+    )
+    ext_table.add_column("Extension", style="bright_white")
+    ext_table.add_column("Files", justify="right", style="green")
 
     for ext, count in sorted(extension_counts.items(), key=lambda item: -item[1]):
-        table.add_row(ext or "(none)", str(count))
+        ext_table.add_row(ext or "(none)", str(count))
 
     console.print()
-    console.print(table)
+    console.print(ext_table)

--- a/foldermix/terminal.py
+++ b/foldermix/terminal.py
@@ -4,6 +4,7 @@ from collections.abc import Iterable
 
 from rich import box
 from rich.console import Console
+from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
@@ -25,9 +26,17 @@ def print_file_table(
     path_attr: str = "relpath",
     size_attr: str = "size",
 ) -> None:
-    table = Table(title=title, box=box.SIMPLE, show_lines=False)
-    table.add_column("Path", overflow="fold")
-    table.add_column("Size", justify="right")
+    table = Table(
+        title=f"📦 {title}",
+        title_style="bold cyan",
+        box=box.ROUNDED,
+        border_style="bright_black",
+        header_style="bold white on dark_green",
+        row_styles=["none", "dim"],
+        show_lines=False,
+    )
+    table.add_column("Path", overflow="fold", style="bright_white")
+    table.add_column("Size", justify="right", style="green")
 
     for record in records:
         table.add_row(
@@ -39,10 +48,18 @@ def print_file_table(
 
 
 def print_skip_table(console: Console, entries: Iterable[dict[str, str]], *, title: str) -> None:
-    table = Table(title=title, box=box.SIMPLE, show_lines=False)
-    table.add_column("Path", overflow="fold")
-    table.add_column("Reason code", no_wrap=True)
-    table.add_column("Message", overflow="fold")
+    table = Table(
+        title=f"⏭ {title}",
+        title_style="bold yellow",
+        box=box.ROUNDED,
+        border_style="bright_black",
+        header_style="bold white on dark_red",
+        row_styles=["none", "dim"],
+        show_lines=False,
+    )
+    table.add_column("Path", overflow="fold", style="bright_white")
+    table.add_column("Reason code", no_wrap=True, style="yellow")
+    table.add_column("Message", overflow="fold", style="white")
 
     for entry in entries:
         table.add_row(
@@ -52,6 +69,114 @@ def print_skip_table(console: Console, entries: Iterable[dict[str, str]], *, tit
         )
 
     console.print(table)
+
+
+def print_preview_summary(
+    console: Console,
+    *,
+    included_count: int,
+    skipped_count: int,
+    converter_missing_count: int | None = None,
+) -> None:
+    parts = [
+        f"[bold green]{format_count(included_count, 'file')}[/bold green] would be included",
+        f"[bold yellow]{format_count(skipped_count, 'file')}[/bold yellow] skipped",
+    ]
+    if converter_missing_count is not None:
+        parts.append(
+            f"[bold magenta]{format_count(converter_missing_count, 'additional file')}[/bold magenta] "
+            "without a supported converter"
+        )
+    console.print(
+        Panel(
+            " • ".join(parts),
+            title="[bold cyan]Preview summary[/bold cyan]",
+            border_style="cyan",
+            padding=(0, 1),
+        )
+    )
+
+
+def print_pack_start(console: Console, *, root: object, output_format: str) -> None:
+    console.print(
+        Panel(
+            f"[bold white]Root:[/bold white] {root}\n"
+            f"[bold white]Format:[/bold white] [cyan]{output_format}[/cyan]",
+            title="[bold cyan]foldermix pack[/bold cyan]",
+            border_style="cyan",
+            padding=(0, 1),
+        )
+    )
+
+
+def print_pack_scan_summary(
+    console: Console,
+    *,
+    included_count: int,
+    skipped_count: int,
+    duplicate_skip_count: int = 0,
+) -> None:
+    parts = [
+        f"[bold green]{format_count(included_count, 'file')}[/bold green] matched",
+        f"[bold yellow]{format_count(skipped_count, 'file')}[/bold yellow] skipped",
+    ]
+    if duplicate_skip_count:
+        parts.append(
+            f"[bold magenta]{format_count(duplicate_skip_count, 'duplicate')}[/bold magenta] "
+            "deduped"
+        )
+    console.print(
+        Panel(
+            " • ".join(parts),
+            title="[bold cyan]Scan summary[/bold cyan]",
+            border_style="bright_black",
+            padding=(0, 1),
+        )
+    )
+
+
+def print_pack_result(
+    console: Console,
+    *,
+    output_path: object,
+    output_format: str,
+    file_count: int,
+    skipped_count: int,
+    total_bytes: int,
+    report_path: object | None = None,
+    policy_finding_count: int | None = None,
+) -> None:
+    table = Table(
+        title="✅ Pack complete",
+        title_style="bold green",
+        box=box.ROUNDED,
+        border_style="green",
+        header_style="bold white on dark_green",
+        show_lines=False,
+    )
+    table.add_column("Field", style="bold cyan", no_wrap=True)
+    table.add_column("Value", style="white", overflow="fold")
+    table.add_row("Output", str(output_path))
+    table.add_row("Format", output_format)
+    table.add_row("Packed files", format_count(file_count, "file"))
+    table.add_row("Skipped files", format_count(skipped_count, "file"))
+    table.add_row("Input bytes", format_bytes(total_bytes))
+    if report_path is not None:
+        table.add_row("Report", str(report_path))
+    if policy_finding_count is not None:
+        table.add_row("Policy findings", str(policy_finding_count))
+
+    console.print(table)
+    console.print(
+        Panel(
+            f"[bold green]{format_count(file_count, 'file')}[/bold green] packed • "
+            f"[bold yellow]{format_count(skipped_count, 'file')}[/bold yellow] skipped • "
+            f"[bold cyan]{format_bytes(total_bytes)}[/bold cyan] -> [bold]{output_path}[/bold]",
+            title="[bold green]Ready[/bold green]",
+            border_style="green",
+            padding=(0, 1),
+        )
+    )
 
 
 def print_stats_table(

--- a/foldermix/terminal.py
+++ b/foldermix/terminal.py
@@ -35,17 +35,25 @@ def print_file_table(
     path_attr: str = "relpath",
     size_attr: str = "size",
 ) -> None:
-    table = Table(
-        title=title,
-        title_style="bold cyan",
-        box=box.ROUNDED,
-        border_style="bright_black",
-        header_style="bold white on dark_green",
-        row_styles=["none", "dim"],
-        show_lines=False,
-    )
-    table.add_column("Path", overflow="fold", style="bright_white")
-    table.add_column("Size", justify="right", style="green")
+    if console.is_terminal:
+        table = Table(
+            title=title,
+            title_style="bold cyan",
+            box=box.ROUNDED,
+            border_style="bright_black",
+            header_style="bold white on dark_green",
+            row_styles=["none", "dim"],
+            show_lines=False,
+        )
+        table.add_column("Path", overflow="fold", style="bright_white")
+        table.add_column("Size", justify="right", style="green")
+    else:
+        # Print title as a plain line so it is never word-wrapped by the table
+        # renderer, then render the table itself without a title.
+        console.print(title)
+        table = Table(box=None, show_header=True)
+        table.add_column("Path", overflow="fold")
+        table.add_column("Size", justify="right")
 
     for record in records:
         table.add_row(
@@ -57,18 +65,25 @@ def print_file_table(
 
 
 def print_skip_table(console: Console, entries: Iterable[dict[str, str]], *, title: str) -> None:
-    table = Table(
-        title=title,
-        title_style="bold yellow",
-        box=box.ROUNDED,
-        border_style="bright_black",
-        header_style="bold white on dark_red",
-        row_styles=["none", "dim"],
-        show_lines=False,
-    )
-    table.add_column("Path", overflow="fold", style="bright_white")
-    table.add_column("Reason code", no_wrap=True, style="yellow")
-    table.add_column("Message", overflow="fold", style="white")
+    if console.is_terminal:
+        table = Table(
+            title=title,
+            title_style="bold yellow",
+            box=box.ROUNDED,
+            border_style="bright_black",
+            header_style="bold white on dark_red",
+            row_styles=["none", "dim"],
+            show_lines=False,
+        )
+        table.add_column("Path", overflow="fold", style="bright_white")
+        table.add_column("Reason code", no_wrap=True, style="yellow")
+        table.add_column("Message", overflow="fold", style="white")
+    else:
+        console.print(title)
+        table = Table(box=None, show_header=True)
+        table.add_column("Path", overflow="fold")
+        table.add_column("Reason code", no_wrap=True)
+        table.add_column("Message", overflow="fold")
 
     for entry in entries:
         table.add_row(
@@ -88,17 +103,31 @@ def print_preview_summary(
     converter_missing_count: int | None = None,
 ) -> None:
     parts = [
+        f"{format_count(included_count, 'file')} would be included",
+        f"{format_count(skipped_count, 'file')} skipped",
+    ]
+    if converter_missing_count is not None:
+        parts.append(
+            f"{format_count(converter_missing_count, 'additional file')} "
+            "without a supported converter"
+        )
+
+    if not console.is_terminal:
+        console.print(" • ".join(parts))
+        return
+
+    rich_parts = [
         f"[bold green]{format_count(included_count, 'file')}[/bold green] would be included",
         f"[bold yellow]{format_count(skipped_count, 'file')}[/bold yellow] skipped",
     ]
     if converter_missing_count is not None:
-        parts.append(
+        rich_parts.append(
             f"[bold magenta]{format_count(converter_missing_count, 'additional file')}[/bold magenta] "
             "without a supported converter"
         )
     console.print(
         Panel(
-            " • ".join(parts),
+            " • ".join(rich_parts),
             title="[bold cyan]Preview summary[/bold cyan]",
             border_style="cyan",
             padding=(0, 1),
@@ -114,17 +143,28 @@ def print_pack_scan_summary(
     duplicate_skip_count: int = 0,
 ) -> None:
     parts = [
+        f"{format_count(included_count, 'file')} matched",
+        f"{format_count(skipped_count, 'file')} skipped",
+    ]
+    if duplicate_skip_count:
+        parts.append(f"{format_count(duplicate_skip_count, 'duplicate')} deduped")
+
+    if not console.is_terminal:
+        console.print(" • ".join(parts))
+        return
+
+    rich_parts = [
         f"[bold green]{format_count(included_count, 'file')}[/bold green] matched",
         f"[bold yellow]{format_count(skipped_count, 'file')}[/bold yellow] skipped",
     ]
     if duplicate_skip_count:
-        parts.append(
+        rich_parts.append(
             f"[bold magenta]{format_count(duplicate_skip_count, 'duplicate')}[/bold magenta] "
             "deduped"
         )
     console.print(
         Panel(
-            " • ".join(parts),
+            " • ".join(rich_parts),
             title="[bold cyan]Scan summary[/bold cyan]",
             border_style="bright_black",
             padding=(0, 1),
@@ -142,6 +182,19 @@ def print_pack_result(
     report_path: Path | str | None = None,
     policy_finding_count: int | None = None,
 ) -> None:
+    if not console.is_terminal:
+        line = (
+            f"Pack complete: {format_count(file_count, 'file')}, "
+            f"{format_size(total_bytes)} -> {output_path}"
+        )
+        if report_path is not None:
+            line += f" (report: {report_path})"
+        if policy_finding_count is not None:
+            line += f" (policy findings: {policy_finding_count})"
+        # markup=False prevents Rich from misinterpreting path characters as tags
+        console.print(line, markup=False)
+        return
+
     table = Table(
         title="✅ Pack complete",
         title_style="bold green",
@@ -173,31 +226,43 @@ def print_stats_table(
     total_bytes: int,
     extension_counts: dict[str, int],
 ) -> None:
-    summary = Table(
-        title=title,
-        title_style="bold cyan",
-        box=box.ROUNDED,
-        border_style="bright_black",
-        header_style="bold white on dark_green",
-        show_lines=False,
-    )
-    summary.add_column("Metric", style="bold cyan", no_wrap=True)
-    summary.add_column("Value", style="white")
+    if console.is_terminal:
+        summary = Table(
+            title=title,
+            title_style="bold cyan",
+            box=box.ROUNDED,
+            border_style="bright_black",
+            header_style="bold white on dark_green",
+            show_lines=False,
+        )
+        summary.add_column("Metric", style="bold cyan", no_wrap=True)
+        summary.add_column("Value", style="white")
+    else:
+        console.print(title)
+        summary = Table(box=None, show_header=True)
+        summary.add_column("Metric", no_wrap=True)
+        summary.add_column("Value")
+
     summary.add_row("Included files", format_count(included_count, "file"))
     summary.add_row("Skipped files", format_count(skipped_count, "file"))
     summary.add_row("Total size", format_size(total_bytes))
     console.print(summary)
 
-    ext_table = Table(
-        title="By extension",
-        title_style="bold cyan",
-        box=box.ROUNDED,
-        border_style="bright_black",
-        header_style="bold white on dark_green",
-        show_lines=False,
-    )
-    ext_table.add_column("Extension", style="bright_white")
-    ext_table.add_column("Files", justify="right", style="green")
+    if console.is_terminal:
+        ext_table = Table(
+            title="By extension",
+            title_style="bold cyan",
+            box=box.ROUNDED,
+            border_style="bright_black",
+            header_style="bold white on dark_green",
+            show_lines=False,
+        )
+        ext_table.add_column("Extension", style="bright_white")
+        ext_table.add_column("Files", justify="right", style="green")
+    else:
+        ext_table = Table(title="By extension", box=None, show_header=True)
+        ext_table.add_column("Extension")
+        ext_table.add_column("Files", justify="right")
 
     for ext, count in sorted(extension_counts.items(), key=lambda item: -item[1]):
         ext_table.add_row(ext or "(none)", str(count))

--- a/foldermix/terminal.py
+++ b/foldermix/terminal.py
@@ -191,8 +191,9 @@ def print_pack_result(
             line += f" (report: {report_path})"
         if policy_finding_count is not None:
             line += f" (policy findings: {policy_finding_count})"
-        # markup=False prevents Rich from misinterpreting path characters as tags
-        console.print(line, markup=False)
+        # markup=False: don't interpret path chars as Rich tags
+        # soft_wrap=True: never word-wrap — keeps the whole line intact for grep/pipes
+        console.print(line, markup=False, soft_wrap=True)
         return
 
     table = Table(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -799,7 +799,7 @@ def test_skiplist_conversion_check_reports_unsupported_extensions(tmp_path: Path
     assert "notes" in result.output
     assert "custom.weird" in result.output
     assert "files without" in result.output
-    assert "an extension" in result.output
+    assert "without an" in result.output
     assert ".weird" in result.output
 
 
@@ -1706,20 +1706,32 @@ from foldermix.terminal import (  # noqa: E402
 
 
 def _rich_capture(fn) -> str:
+    """Capture output from a Rich-enabled (is_terminal=True) console."""
+    buf = StringIO()
+    con = _Console(file=buf, width=200, no_color=True, highlight=False, force_terminal=True)
+    fn(con)
+    return buf.getvalue()
+
+
+def _plain_capture(fn) -> str:
+    """Capture output from a non-terminal (is_terminal=False) console."""
     buf = StringIO()
     con = _Console(file=buf, width=200, no_color=True, highlight=False)
     fn(con)
     return buf.getvalue()
 
 
-def test_print_preview_summary_shows_included_and_skipped_counts() -> None:
+# ── Rich (TTY) path ───────────────────────────────────────────────────────────
+
+
+def test_print_preview_summary_rich_shows_panel_and_counts() -> None:
     out = _rich_capture(lambda c: print_preview_summary(c, included_count=5, skipped_count=2))
     assert "5 files" in out
     assert "2 files" in out
     assert "Preview summary" in out
 
 
-def test_print_preview_summary_shows_converter_missing_when_provided() -> None:
+def test_print_preview_summary_rich_shows_converter_missing_when_provided() -> None:
     out = _rich_capture(
         lambda c: print_preview_summary(
             c, included_count=3, skipped_count=1, converter_missing_count=2
@@ -1729,19 +1741,19 @@ def test_print_preview_summary_shows_converter_missing_when_provided() -> None:
     assert "converter" in out
 
 
-def test_print_preview_summary_omits_converter_field_when_absent() -> None:
+def test_print_preview_summary_rich_omits_converter_field_when_absent() -> None:
     out = _rich_capture(lambda c: print_preview_summary(c, included_count=3, skipped_count=1))
     assert "converter" not in out
 
 
-def test_print_pack_scan_summary_shows_matched_and_skipped() -> None:
+def test_print_pack_scan_summary_rich_shows_panel_and_counts() -> None:
     out = _rich_capture(lambda c: print_pack_scan_summary(c, included_count=10, skipped_count=3))
     assert "10 files" in out
     assert "3 files" in out
     assert "Scan summary" in out
 
 
-def test_print_pack_scan_summary_shows_deduped_count_when_nonzero() -> None:
+def test_print_pack_scan_summary_rich_shows_deduped_count_when_nonzero() -> None:
     out = _rich_capture(
         lambda c: print_pack_scan_summary(
             c, included_count=8, skipped_count=2, duplicate_skip_count=1
@@ -1751,7 +1763,7 @@ def test_print_pack_scan_summary_shows_deduped_count_when_nonzero() -> None:
     assert "deduped" in out
 
 
-def test_print_pack_scan_summary_omits_deduped_when_zero() -> None:
+def test_print_pack_scan_summary_rich_omits_deduped_when_zero() -> None:
     out = _rich_capture(
         lambda c: print_pack_scan_summary(
             c, included_count=5, skipped_count=0, duplicate_skip_count=0
@@ -1760,7 +1772,7 @@ def test_print_pack_scan_summary_omits_deduped_when_zero() -> None:
     assert "deduped" not in out
 
 
-def test_print_pack_result_shows_output_files_size(tmp_path: Path) -> None:
+def test_print_pack_result_rich_shows_table_with_output_files_size(tmp_path: Path) -> None:
     out_file = tmp_path / "out.md"
     out = _rich_capture(
         lambda c: print_pack_result(
@@ -1778,7 +1790,7 @@ def test_print_pack_result_shows_output_files_size(tmp_path: Path) -> None:
     assert "Pack complete" in out
 
 
-def test_print_pack_result_shows_report_and_policy_when_provided(tmp_path: Path) -> None:
+def test_print_pack_result_rich_shows_report_and_policy_when_provided(tmp_path: Path) -> None:
     out_file = tmp_path / "out.md"
     report_file = tmp_path / "report.json"
     out = _rich_capture(
@@ -1796,7 +1808,7 @@ def test_print_pack_result_shows_report_and_policy_when_provided(tmp_path: Path)
     assert "4" in out
 
 
-def test_print_pack_result_omits_report_and_policy_when_absent(tmp_path: Path) -> None:
+def test_print_pack_result_rich_omits_report_and_policy_when_absent(tmp_path: Path) -> None:
     out_file = tmp_path / "out.md"
     out = _rich_capture(
         lambda c: print_pack_result(
@@ -1809,3 +1821,78 @@ def test_print_pack_result_omits_report_and_policy_when_absent(tmp_path: Path) -
     )
     assert "Report" not in out
     assert "Policy findings" not in out
+
+
+# ── Plain (non-TTY) path ──────────────────────────────────────────────────────
+
+
+def test_print_preview_summary_plain_emits_single_line() -> None:
+    out = _plain_capture(lambda c: print_preview_summary(c, included_count=5, skipped_count=2))
+    assert "5 files" in out
+    assert "2 files" in out
+    assert "Preview summary" not in out  # no panel border/title
+    assert "\n" not in out.strip()  # single line
+
+
+def test_print_preview_summary_plain_includes_converter_when_provided() -> None:
+    out = _plain_capture(
+        lambda c: print_preview_summary(
+            c, included_count=3, skipped_count=1, converter_missing_count=2
+        )
+    )
+    assert "2 additional files" in out
+    assert "converter" in out
+
+
+def test_print_pack_scan_summary_plain_emits_single_line() -> None:
+    out = _plain_capture(lambda c: print_pack_scan_summary(c, included_count=10, skipped_count=3))
+    assert "10 files" in out
+    assert "3 files" in out
+    assert "Scan summary" not in out  # no panel border/title
+    assert "\n" not in out.strip()
+
+
+def test_print_pack_scan_summary_plain_includes_deduped_when_nonzero() -> None:
+    out = _plain_capture(
+        lambda c: print_pack_scan_summary(
+            c, included_count=8, skipped_count=2, duplicate_skip_count=3
+        )
+    )
+    assert "3 duplicates" in out
+    assert "deduped" in out
+
+
+def test_print_pack_result_plain_emits_single_line(tmp_path: Path) -> None:
+    out_file = tmp_path / "out.md"
+    out = _plain_capture(
+        lambda c: print_pack_result(
+            c,
+            output_path=out_file,
+            file_count=7,
+            skipped_count=2,
+            total_bytes=2048,
+        )
+    )
+    assert "7 files" in out
+    assert "2.0 KB" in out
+    assert str(out_file) in out
+    assert "Pack complete" in out
+    assert "\n" not in out.strip()
+
+
+def test_print_pack_result_plain_includes_report_and_policy(tmp_path: Path) -> None:
+    out_file = tmp_path / "out.md"
+    report_file = tmp_path / "report.json"
+    out = _plain_capture(
+        lambda c: print_pack_result(
+            c,
+            output_path=out_file,
+            file_count=3,
+            skipped_count=0,
+            total_bytes=512,
+            report_path=report_file,
+            policy_finding_count=4,
+        )
+    )
+    assert str(report_file) in out
+    assert "policy findings: 4" in out  # uses parens, not Rich markup brackets

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1699,9 +1699,12 @@ from io import StringIO  # noqa: E402
 from rich.console import Console as _Console  # noqa: E402
 
 from foldermix.terminal import (  # noqa: E402
+    print_file_table,
     print_pack_result,
     print_pack_scan_summary,
     print_preview_summary,
+    print_skip_table,
+    print_stats_table,
 )
 
 
@@ -1896,3 +1899,47 @@ def test_print_pack_result_plain_includes_report_and_policy(tmp_path: Path) -> N
     )
     assert str(report_file) in out
     assert "policy findings: 4" in out  # uses parens, not Rich markup brackets
+
+
+def test_print_file_table_rich_renders_styled_table() -> None:
+    from types import SimpleNamespace
+
+    records = [SimpleNamespace(relpath="a.txt", size=1024)]
+    out = _rich_capture(lambda c: print_file_table(c, records, title="Test files"))
+    assert "Test files" in out
+    assert "a.txt" in out
+    assert "1.0 KB" in out
+    assert "Path" in out
+    assert "Size" in out
+
+
+def test_print_skip_table_rich_renders_styled_table() -> None:
+    entries = [{"path": "skip.txt", "reason_code": "SKIP_HIDDEN", "message": "Hidden file"}]
+    out = _rich_capture(lambda c: print_skip_table(c, entries, title="Test skips"))
+    assert "Test skips" in out
+    assert "skip.txt" in out
+    assert "SKIP_HIDDEN" in out
+    assert "Hidden file" in out
+    assert "Path" in out
+    assert "Reason code" in out
+    assert "Message" in out
+
+
+def test_print_stats_table_rich_renders_styled_tables() -> None:
+    out = _rich_capture(
+        lambda c: print_stats_table(
+            c,
+            title="Stats",
+            included_count=3,
+            skipped_count=1,
+            total_bytes=2048,
+            extension_counts={".py": 2, ".md": 1},
+        )
+    )
+    assert "Stats" in out
+    assert "3 files" in out
+    assert "1 file" in out
+    assert "2.0 KB" in out
+    assert "By extension" in out
+    assert ".py" in out
+    assert ".md" in out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,7 +11,7 @@ import foldermix.scanner as scanner_module
 from foldermix import __version__
 from foldermix import cli as cli_module
 from foldermix.cli import app
-from foldermix.terminal import format_bytes, format_count
+from foldermix.terminal import format_bytes, format_count, format_size
 
 runner = CliRunner()
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
@@ -28,6 +28,17 @@ def test_terminal_count_formatting_handles_singular_and_plural() -> None:
     assert format_count(0, "additional file") == "0 additional files"
     assert format_bytes(1) == "1 byte"
     assert format_bytes(2) == "2 bytes"
+
+
+def test_format_size_returns_human_readable_units() -> None:
+    assert format_size(0) == "0 bytes"
+    assert format_size(1) == "1 byte"
+    assert format_size(512) == "512 bytes"
+    assert format_size(1023) == "1,023 bytes"
+    assert format_size(1024) == "1.0 KB"
+    assert format_size(1536) == "1.5 KB"
+    assert format_size(1024 * 1024) == "1.0 MB"
+    assert format_size(1024 * 1024 * 1024) == "1.0 GB"
 
 
 def test_pack_rejects_invalid_format(tmp_path: Path) -> None:
@@ -1467,8 +1478,10 @@ def test_stats_prints_summary_and_extensions(tmp_path: Path) -> None:
     result = runner.invoke(app, ["stats", str(tmp_path)])
 
     assert result.exit_code == 0, result.output
-    assert "Included files: 3" in result.output
-    assert "Skipped files:  0" in result.output
+    assert "Included files" in result.output
+    assert "3 files" in result.output
+    assert "Skipped files" in result.output
+    assert "0 files" in result.output
     assert ".py" in result.output
     assert ".md" in result.output
     assert "By extension" in result.output
@@ -1677,3 +1690,122 @@ def test_root_help_lists_all_commands() -> None:
     assert "foldermix.github.io/foldermix/quickstart" in result.output
     assert "foldermix.github.io/foldermix/workflows" in result.output
     assert "foldermix.github.io/foldermix/safety-and-troubleshooting" in result.output
+
+
+# ── terminal widget unit tests ────────────────────────────────────────────────
+
+from io import StringIO  # noqa: E402
+
+from rich.console import Console as _Console  # noqa: E402
+
+from foldermix.terminal import (  # noqa: E402
+    print_pack_result,
+    print_pack_scan_summary,
+    print_preview_summary,
+)
+
+
+def _rich_capture(fn) -> str:
+    buf = StringIO()
+    con = _Console(file=buf, width=200, no_color=True, highlight=False)
+    fn(con)
+    return buf.getvalue()
+
+
+def test_print_preview_summary_shows_included_and_skipped_counts() -> None:
+    out = _rich_capture(lambda c: print_preview_summary(c, included_count=5, skipped_count=2))
+    assert "5 files" in out
+    assert "2 files" in out
+    assert "Preview summary" in out
+
+
+def test_print_preview_summary_shows_converter_missing_when_provided() -> None:
+    out = _rich_capture(
+        lambda c: print_preview_summary(
+            c, included_count=3, skipped_count=1, converter_missing_count=2
+        )
+    )
+    assert "2 additional files" in out
+    assert "converter" in out
+
+
+def test_print_preview_summary_omits_converter_field_when_absent() -> None:
+    out = _rich_capture(lambda c: print_preview_summary(c, included_count=3, skipped_count=1))
+    assert "converter" not in out
+
+
+def test_print_pack_scan_summary_shows_matched_and_skipped() -> None:
+    out = _rich_capture(lambda c: print_pack_scan_summary(c, included_count=10, skipped_count=3))
+    assert "10 files" in out
+    assert "3 files" in out
+    assert "Scan summary" in out
+
+
+def test_print_pack_scan_summary_shows_deduped_count_when_nonzero() -> None:
+    out = _rich_capture(
+        lambda c: print_pack_scan_summary(
+            c, included_count=8, skipped_count=2, duplicate_skip_count=1
+        )
+    )
+    assert "1 duplicate" in out
+    assert "deduped" in out
+
+
+def test_print_pack_scan_summary_omits_deduped_when_zero() -> None:
+    out = _rich_capture(
+        lambda c: print_pack_scan_summary(
+            c, included_count=5, skipped_count=0, duplicate_skip_count=0
+        )
+    )
+    assert "deduped" not in out
+
+
+def test_print_pack_result_shows_output_files_size(tmp_path: Path) -> None:
+    out_file = tmp_path / "out.md"
+    out = _rich_capture(
+        lambda c: print_pack_result(
+            c,
+            output_path=out_file,
+            file_count=7,
+            skipped_count=2,
+            total_bytes=2048,
+        )
+    )
+    assert str(out_file) in out
+    assert "7 files" in out
+    assert "2 files" in out
+    assert "2.0 KB" in out
+    assert "Pack complete" in out
+
+
+def test_print_pack_result_shows_report_and_policy_when_provided(tmp_path: Path) -> None:
+    out_file = tmp_path / "out.md"
+    report_file = tmp_path / "report.json"
+    out = _rich_capture(
+        lambda c: print_pack_result(
+            c,
+            output_path=out_file,
+            file_count=3,
+            skipped_count=0,
+            total_bytes=512,
+            report_path=report_file,
+            policy_finding_count=4,
+        )
+    )
+    assert str(report_file) in out
+    assert "4" in out
+
+
+def test_print_pack_result_omits_report_and_policy_when_absent(tmp_path: Path) -> None:
+    out_file = tmp_path / "out.md"
+    out = _rich_capture(
+        lambda c: print_pack_result(
+            c,
+            output_path=out_file,
+            file_count=3,
+            skipped_count=0,
+            total_bytes=512,
+        )
+    )
+    assert "Report" not in out
+    assert "Policy findings" not in out

--- a/tests/test_cli_stdin.py
+++ b/tests/test_cli_stdin.py
@@ -104,9 +104,11 @@ def test_list_and_stats_stdin_use_only_explicit_paths(monkeypatch, tmp_path: Pat
         input="a.txt\nb.txt\nmissing.txt\n",
     )
     assert stats_result.exit_code == 0, stats_result.output
-    assert "Included files: 2" in stats_result.output
-    assert "Skipped files:  1" in stats_result.output
-    assert "Total bytes:    3" in stats_result.output
+    assert "Included files" in stats_result.output
+    assert "2 files" in stats_result.output
+    assert "Skipped files" in stats_result.output
+    assert "1 file" in stats_result.output
+    assert "Total size" in stats_result.output
     assert "By extension" in stats_result.output
 
 


### PR DESCRIPTION
## Summary

- Restyle `foldermix list` and `foldermix skiplist` with richer Rich tables and preview summary panels.
- Add richer `foldermix pack` terminal output: start panel, scan summary, destination status, completion table, and final ready panel.
- Keep existing summary/status strings in place where practical so current tests and downstream parsing expectations remain stable.

## Behavior change

- `list` now prints the existing included-file table with stronger visual styling and a `Preview summary` panel.
- `skiplist` now prints the existing skipped-file table with stronger visual styling and a `Preview summary` panel, including converter-missing counts when `--conversion-check` is used.
- `pack` now presents the run as a structured Rich flow while still emitting the existing `Done! ... -> output` completion line.

## Flags and config keys

- No new CLI flags.
- No config key changes.
- No dependency changes; this reuses the existing `rich` dependency.

## Validation

- `uv run pytest -q -o addopts= tests/test_cli.py tests/test_packer.py tests/test_packer_edges.py`
- `ruff check foldermix/cli.py foldermix/packer.py foldermix/terminal.py`
- `ruff format --check foldermix/cli.py foldermix/packer.py foldermix/terminal.py`
- pre-commit hooks during commit, including `pytest-fast`

## Notes

This is CLI presentation work only; the desktop wrapper changes remain out of this PR.
