### PR TITLE
fix(ci): update release-consumer smoke assertions for new list output format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,8 @@ jobs:
 
           list_out="$(run_expect 0 ./.pkg-smoke-venv/bin/foldermix list smoke_input)"
           assert_contains "$list_out" "a.txt"
-          assert_contains "$list_out" "1 file would be included, 0 files skipped."
+          assert_contains "$list_out" "1 file would be included"
+          assert_contains "$list_out" "0 files skipped"
 
           stats_out="$(run_expect 0 ./.pkg-smoke-venv/bin/foldermix stats smoke_input)"
           assert_contains "$stats_out" "Included files"
@@ -499,7 +500,8 @@ jobs:
 
           list_out="$(run_expect_zero ./.release-consumer-venv/bin/foldermix list smoke_input)"
           assert_contains "$list_out" "a.txt"
-          assert_contains "$list_out" "1 files would be included, 0 skipped."
+          assert_contains "$list_out" "1 file would be included"
+          assert_contains "$list_out" "0 files skipped"
 
           pack_out="$(
             run_expect_zero ./.release-consumer-venv/bin/foldermix pack smoke_input --out release_consumer_output.md
@@ -576,7 +578,8 @@ jobs:
 
           list_out="$(run_expect_zero foldermix list smoke_input)"
           assert_contains "$list_out" "a.txt"
-          assert_contains "$list_out" "1 files would be included, 0 skipped."
+          assert_contains "$list_out" "1 file would be included"
+          assert_contains "$list_out" "0 files skipped"
 
           pack_out="$(run_expect_zero foldermix pack smoke_input --out release_consumer_output.md)"
           assert_contains "$pack_out" "Done!"


### PR DESCRIPTION
The Rich output refactor (#152) changed the non-TTY `foldermix list` summary from:

```
1 files would be included, 0 skipped.
```
to:
```
1 file would be included • 0 files skipped
```

Three assertions in the `package-smoke`, `release-consumer-smoke-pypi`, and `release-consumer-smoke-homebrew` jobs were stale. Fixed by asserting each part independently, which is also more robust against separator changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)