### PR TITLE
fix(ci): switch pathspec to gitwildmatch, suppress coverage in pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
     hooks:
       - id: pytest-fast
         name: pytest-fast
-        entry: python -m pytest -m "not integration and not slow" -o addopts="-vv -ra --strict-markers --strict-config"
+        entry: python -m pytest -m "not integration and not slow" -o addopts="-vv -ra --strict-markers --strict-config --no-cov"
         language: python
         additional_dependencies:
           - "pytest>=7.0"

--- a/foldermix/scanner.py
+++ b/foldermix/scanner.py
@@ -54,7 +54,7 @@ def _load_gitignore_spec(root: Path, respect_gitignore: bool) -> pathspec.PathSp
     if not gitignore_path.exists():
         return None
     patterns = gitignore_path.read_text().splitlines()
-    return pathspec.PathSpec.from_lines("gitignore", patterns)
+    return pathspec.PathSpec.from_lines("gitwildmatch", patterns)
 
 
 def _normalize_include_exts(config: PackConfig) -> set[str] | None:


### PR DESCRIPTION
## Summary

- `foldermix/scanner.py`: switch `pathspec.PathSpec.from_lines` factory from deprecated `"gitignore"` to `"gitwildmatch"`. With `filterwarnings = ["error"]` in pyproject.toml the DeprecationWarning from pathspec was being raised as an exception, causing `test_respect_gitignore` to fail.
- `.pre-commit-config.yaml`: add `--no-cov` to the `pytest-fast` hook entry so the 98% coverage threshold doesn't fire in the hook's isolated environment (where the installed package path doesn't match source, yielding ~8% reported coverage).

## Test plan

- [ ] All 497 non-integration/non-slow tests pass locally (`python -m pytest -m "not integration and not slow" --no-cov`)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)