### PR TITLE
Improve README onboarding flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,38 +2,26 @@
 
 `foldermix` packs a local folder into one LLM-friendly context artifact you can inspect, share, or pipe into automation.
 
-Created and maintained by [Shay Palachy Affek](https://www.shaypalachy.com/).
+Created by [Shay Palachy Affek](http://www.shaypalachy.com/).
 
 [![CI](https://github.com/foldermix/foldermix/actions/workflows/ci.yml/badge.svg)](https://github.com/foldermix/foldermix/actions/workflows/ci.yml)
 
 Docs site: [foldermix.github.io/foldermix](https://foldermix.github.io/foldermix/)
 
+## Quick Start
+
 ```bash
-pip install foldermix && foldermix pack . --out context.md
+pip install foldermix
+foldermix pack . --out context.md
 ```
 
-That command writes a Markdown bundle for the current folder:
+That command scans the current folder and writes one Markdown context artifact:
 
-````markdown
-# FolderPack Context
-
-- **Root**: `/path/to/project`
-- **Files**: 2
-- **Total bytes**: 32
-
-## Table of Contents
-
-- [README.md](#readmemd)
-- [src/app.py](#srcapppy)
-
----
-
-## src/app.py {#srcapppy}
-
-```python
-print("hello")
+```text
+project folder -> scan/filter/convert -> context.md -> ChatGPT / Claude / Gemini / local agents
 ```
-````
+
+For a full generated Markdown bundle, see [docs/examples/packed-output.md](docs/examples/packed-output.md).
 
 Before it writes output, `foldermix` keeps the run predictable:
 
@@ -43,6 +31,20 @@ Before it writes output, `foldermix` keeps the run predictable:
 - orders files deterministically
 - lets you inspect included and skipped files with `list`, `skiplist`, `preview`, `stats`, and `--report`
 - supports redaction, size limits, duplicate suppression, and policy dry-runs when a workflow needs stricter controls
+
+## Workflow
+
+```mermaid
+flowchart LR
+    folder["Local folder"] --> list["foldermix list"]
+    folder --> skiplist["foldermix skiplist"]
+    folder --> stats["foldermix stats"]
+    list --> pack["foldermix pack"]
+    skiplist --> pack
+    stats --> pack
+    pack --> artifact["md / xml / jsonl context artifact"]
+    artifact --> llm["LLM or automation workflow"]
+```
 
 ## Install
 
@@ -80,7 +82,7 @@ brew uninstall foldermix
 uv tool install "foldermix[all,markitdown]"
 ```
 
-## Quick Start
+## First Commands
 
 Run from the folder you want to pack:
 
@@ -715,7 +717,7 @@ For maintainers preparing a possible `homebrew/core` submission, see [docs/homeb
 
 ## Credits
 
-foldermix was created and is maintained by [Shay Palachy Affek](https://www.shaypalachy.com/).
+Created by [Shay Palachy Affek ](http://www.shaypalachy.com/) [[GitHub](https://github.com/shaypal5)]
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ That command scans the current folder and writes one Markdown context artifact:
 project folder -> scan/filter/convert -> context.md -> ChatGPT / Claude / Gemini / local agents
 ```
 
-For a full generated Markdown bundle, see [docs/examples/packed-output.md](docs/examples/packed-output.md).
+For a minimal generated Markdown example, see [docs/examples/packed-output.md](docs/examples/packed-output.md).
 
 Before it writes output, `foldermix` keeps the run predictable:
 

--- a/docs/examples/packed-output.md
+++ b/docs/examples/packed-output.md
@@ -1,0 +1,31 @@
+# Example Packed Output
+
+This is a minimal example of the Markdown artifact written by:
+
+```bash
+foldermix pack . --out context.md
+```
+
+````markdown
+# FolderPack Context
+
+- **Root**: `/path/to/project`
+- **Files**: 2
+- **Total bytes**: 32
+
+## Table of Contents
+
+- [README.md](#readmemd)
+- [src/app.py](#srcapppy)
+
+---
+
+## src/app.py {#srcapppy}
+
+```python
+print("hello")
+```
+````
+
+Real bundles include one section per included file, plus metadata controlled by the selected output
+format and config.

--- a/docs/examples/packed-output.md
+++ b/docs/examples/packed-output.md
@@ -11,12 +11,20 @@ foldermix pack . --out context.md
 
 - **Root**: `/path/to/project`
 - **Files**: 2
-- **Total bytes**: 32
+- **Total bytes**: 58
 
 ## Table of Contents
 
 - [README.md](#readmemd)
 - [src/app.py](#srcapppy)
+
+---
+
+## README.md {#readmemd}
+
+```markdown
+# Example Project
+```
 
 ---
 

--- a/foldermix/effective_config.py
+++ b/foldermix/effective_config.py
@@ -5,13 +5,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal, Protocol
 
-from click.core import ParameterSource
-
 ConfigSource = Literal["default", "config", "cli"]
 
 
 class ParameterSourceContext(Protocol):
-    def get_parameter_source(self, param_name: str) -> ParameterSource | None: ...
+    def get_parameter_source(self, param_name: str) -> object | None: ...
 
 
 @dataclass(slots=True, frozen=True)
@@ -33,7 +31,8 @@ def merge_config_layers(
 
     for key in values:
         param_name = param_names.get(key, key)
-        if ctx.get_parameter_source(param_name) == ParameterSource.COMMANDLINE:
+        source = ctx.get_parameter_source(param_name)
+        if getattr(source, "name", None) == "COMMANDLINE":
             sources[key] = "cli"
         else:
             sources[key] = "default"

--- a/foldermix/scanner.py
+++ b/foldermix/scanner.py
@@ -54,7 +54,7 @@ def _load_gitignore_spec(root: Path, respect_gitignore: bool) -> pathspec.PathSp
     if not gitignore_path.exists():
         return None
     patterns = gitignore_path.read_text().splitlines()
-    return pathspec.PathSpec.from_lines("gitwildmatch", patterns)
+    return pathspec.PathSpec.from_lines("gitignore", patterns)
 
 
 def _normalize_include_exts(config: PackConfig) -> set[str] | None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1775,8 +1775,8 @@ def test_print_pack_scan_summary_rich_omits_deduped_when_zero() -> None:
     assert "deduped" not in out
 
 
-def test_print_pack_result_rich_shows_table_with_output_files_size(tmp_path: Path) -> None:
-    out_file = tmp_path / "out.md"
+def test_print_pack_result_rich_shows_table_with_output_files_size() -> None:
+    out_file = Path("build/out.md")
     out = _rich_capture(
         lambda c: print_pack_result(
             c,
@@ -1793,9 +1793,9 @@ def test_print_pack_result_rich_shows_table_with_output_files_size(tmp_path: Pat
     assert "Pack complete" in out
 
 
-def test_print_pack_result_rich_shows_report_and_policy_when_provided(tmp_path: Path) -> None:
-    out_file = tmp_path / "out.md"
-    report_file = tmp_path / "report.json"
+def test_print_pack_result_rich_shows_report_and_policy_when_provided() -> None:
+    out_file = Path("build/out.md")
+    report_file = Path("build/report.json")
     out = _rich_capture(
         lambda c: print_pack_result(
             c,

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -96,18 +96,18 @@ def test_init_force_overwrites_existing_file(tmp_path: Path) -> None:
     assert output_path.read_text(encoding="utf-8") != "sentinel\n"
 
 
-def test_init_success_message_shell_quotes_output_path() -> None:
-    with runner.isolated_filesystem():
-        output_path = Path("my profile config.toml")
-        result = runner.invoke(
-            app,
-            ["init", "--profile", "legal", "--out", str(output_path)],
-        )
+def test_init_success_message_shell_quotes_output_path(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+    output_path = Path("my profile config.toml")
+    result = runner.invoke(
+        app,
+        ["init", "--profile", "legal", "--out", str(output_path)],
+    )
 
-        assert result.exit_code == 0, result.output
-        assert "Run:" in result.output
-        expected_tail = f"foldermix pack . --config {shlex.quote(str(output_path))}"
-        assert expected_tail in result.output
+    assert result.exit_code == 0, result.output
+    assert "Run:" in result.output
+    expected_tail = f"foldermix pack . --config {shlex.quote(str(output_path))}"
+    assert expected_tail in result.output
 
 
 def test_init_reports_write_failure(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

This PR tightens the foldermix README first impression by moving the generated `FolderPack Context` sample out of the opening flow and replacing it with a concise quick start plus a workflow diagram.

## First-impression fixes

- Makes install + first `foldermix pack` command visible immediately.
- Replaces the top generated-output dump with a compact `folder -> scan/filter/convert -> context artifact -> LLM` explanation.
- Adds a Mermaid workflow diagram for `list`, `skiplist`, `stats`, and `pack`.
- Moves the full packed-output sample to `docs/examples/packed-output.md`.
- Updates the README Credits line to the current requested format.

## Repository settings

- Updated homepage to `https://foldermix.github.io/foldermix/`.
- Updated description to: `Pack local folders into single LLM-friendly context files for ChatGPT, Claude, Gemini, and automation.`
- Added topics: `llm`, `context-packing`, `cli`, `python`, `developer-tools`, `ai-tools`.

## CI compatibility follow-up

- Made effective-config source detection robust to Typer/Click parameter-source enum drift.
- Switched `.gitignore` parsing to the non-deprecated `pathspec` factory for current `pathspec`.
- Removed fragile test assumptions around Typer test-runner helpers and Rich table wrapping.

## Validation

- `git diff --check`
- Verified `docs/examples/packed-output.md` exists.
- `.venv/bin/python -m pytest -q -o addopts= tests/test_cli_entrypoint.py`
- `.venv/bin/python -m pytest -q -o addopts= tests/test_cli.py::test_pack_rejects_policy_output_without_policy_dry_run tests/test_cli.py::test_pack_rejects_policy_output_text_without_policy_dry_run tests/test_cli.py::test_pack_cli_flags_override_config_values tests/test_cli.py::test_pack_print_effective_config_outputs_sources_and_exits tests/test_cli.py::test_list_print_effective_config_outputs_sources_and_exits tests/test_cli.py::test_stats_print_effective_config_outputs_sources_and_exits tests/test_cli.py::test_preview_print_effective_config_outputs_sources_and_exits tests/test_cli.py::test_skiplist_print_effective_config_outputs_sources_and_exits tests/test_cli_init.py::test_init_success_message_shell_quotes_output_path tests/test_scanner.py::test_respect_gitignore tests/test_cli.py::test_print_pack_result_rich_shows_table_with_output_files_size tests/test_cli.py::test_print_pack_result_rich_shows_report_and_policy_when_provided`
- `uv run ruff check foldermix tests`
- `uv run --with 'typer==0.26.4' --with 'click==8.4.1' --with 'pathspec==1.1.1' --with 'pytest>=9' --with 'pytest-cov' --python 3.12 python -m pytest -m "not integration and not slow" -o addopts="-vv -ra --strict-markers --strict-config --no-cov"`\n\n## Milestone\n\nAssigned to `M3 CLI Presentation & Docs`.\n