### PR TITLE
Promote main site link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Created by [Shay Palachy Affek](http://www.shaypalachy.com/).
 
 [![CI](https://github.com/foldermix/foldermix/actions/workflows/ci.yml/badge.svg)](https://github.com/foldermix/foldermix/actions/workflows/ci.yml)
 
+Main site: [foldermix.github.io](https://foldermix.github.io/)
+
 Docs site: [foldermix.github.io/foldermix](https://foldermix.github.io/foldermix/)
 
 ## Quick Start


### PR DESCRIPTION
## Summary

Promote the main foldermix website link near the top of the README and keep the docs-site link immediately after it.

## Why

The README previously linked only to the docs site in the opening block. New visitors should see the main project site first, then the more specific docs site.

## Validation

- `git diff --check`
- pre-commit hooks during commit

## Notes

This is a documentation-only follow-up to PR #157.
